### PR TITLE
Added Beaver County and Cache County 2012 general

### DIFF
--- a/2012/20121106__ut__general__beaver__precinct.csv
+++ b/2012/20121106__ut__general__beaver__precinct.csv
@@ -1,0 +1,262 @@
+county,precinct,office,district,party,candidate,votes
+Beaver County,Beaver 1,Straight Ticket,,Republican (REP),,130
+Beaver County,Beaver 1,Straight Ticket,,Democratic (DEM),,15
+Beaver County,Beaver 1,Straight Ticket,,Constitution (CON),,2
+Beaver County,Beaver 1,Straight Ticket,,Justice (JUS),,1
+Beaver County,Beaver 1,Straight Ticket,,Libertarian (LIB),,1
+Beaver County,Beaver 1,Straight Ticket,,Green (GRN),,1
+Beaver County,Beaver 2,Straight Ticket,,Republican (REP),,98
+Beaver County,Beaver 2,Straight Ticket,,Democratic (DEM),,18
+Beaver County,Beaver 2,Straight Ticket,,Constitution (CON),,1
+Beaver County,Beaver 2,Straight Ticket,,Justice (JUS),,0
+Beaver County,Beaver 2,Straight Ticket,,Libertarian (LIB),,0
+Beaver County,Beaver 2,Straight Ticket,,Green (GRN),,2
+Beaver County,Beaver 3,Straight Ticket,,Republican (REP),,88
+Beaver County,Beaver 3,Straight Ticket,,Democratic (DEM),,11
+Beaver County,Beaver 3,Straight Ticket,,Constitution (CON),,1
+Beaver County,Beaver 3,Straight Ticket,,Justice (JUS),,0
+Beaver County,Beaver 3,Straight Ticket,,Libertarian (LIB),,2
+Beaver County,Beaver 3,Straight Ticket,,Green (GRN),,0
+Beaver County,Beaver 4,Straight Ticket,,Republican (REP),,47
+Beaver County,Beaver 4,Straight Ticket,,Democratic (DEM),,11
+Beaver County,Beaver 4,Straight Ticket,,Constitution (CON),,2
+Beaver County,Beaver 4,Straight Ticket,,Justice (JUS),,0
+Beaver County,Beaver 4,Straight Ticket,,Libertarian (LIB),,1
+Beaver County,Beaver 4,Straight Ticket,,Green (GRN),,0
+Beaver County,Greenville,Straight Ticket,,Republican (REP),,16
+Beaver County,Greenville,Straight Ticket,,Democratic (DEM),,3
+Beaver County,Greenville,Straight Ticket,,Constitution (CON),,0
+Beaver County,Greenville,Straight Ticket,,Justice (JUS),,0
+Beaver County,Greenville,Straight Ticket,,Libertarian (LIB),,0
+Beaver County,Greenville,Straight Ticket,,Green (GRN),,0
+Beaver County,Milford 1,Straight Ticket,,Republican (REP),,12
+Beaver County,Milford 1,Straight Ticket,,Democratic (DEM),,10
+Beaver County,Milford 1,Straight Ticket,,Constitution (CON),,0
+Beaver County,Milford 1,Straight Ticket,,Justice (JUS),,1
+Beaver County,Milford 1,Straight Ticket,,Libertarian (LIB),,0
+Beaver County,Milford 1,Straight Ticket,,Green (GRN),,0
+Beaver County,Milford 2,Straight Ticket,,Republican (REP),,60
+Beaver County,Milford 2,Straight Ticket,,Democratic (DEM),,46
+Beaver County,Milford 2,Straight Ticket,,Constitution (CON),,1
+Beaver County,Milford 2,Straight Ticket,,Justice (JUS),,2
+Beaver County,Milford 2,Straight Ticket,,Libertarian (LIB),,4
+Beaver County,Milford 2,Straight Ticket,,Green (GRN),,1
+Beaver County,Milford 3,Straight Ticket,,Republican (REP),,30
+Beaver County,Milford 3,Straight Ticket,,Democratic (DEM),,9
+Beaver County,Milford 3,Straight Ticket,,Constitution (CON),,0
+Beaver County,Milford 3,Straight Ticket,,Justice (JUS),,0
+Beaver County,Milford 3,Straight Ticket,,Libertarian (LIB),,1
+Beaver County,Milford 3,Straight Ticket,,Green (GRN),,0
+Beaver County,Minersville,Straight Ticket,,Republican (REP),,136
+Beaver County,Minersville,Straight Ticket,,Democratic (DEM),,12
+Beaver County,Minersville,Straight Ticket,,Constitution (CON),,0
+Beaver County,Minersville,Straight Ticket,,Justice (JUS),,0
+Beaver County,Minersville,Straight Ticket,,Libertarian (LIB),,0
+Beaver County,Minersville,Straight Ticket,,Green (GRN),,0
+Beaver County,Beaver 1,U.S. House of Representatives,2,REP,Chris Stewart,491
+Beaver County,Beaver 1,U.S. House of Representatives,2,DEM,Jay Seegmiller,68
+Beaver County,Beaver 1,U.S. House of Representatives,2,UNA,Charles E. Kimball,3
+Beaver County,Beaver 1,U.S. House of Representatives,2,CON,Jonathan D. Garrard,4
+Beaver County,Beaver 1,U.S. House of Representatives,2,,Joseph Andrade,2
+Beaver County,Beaver 1,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Beaver 2,U.S. House of Representatives,2,REP,Chris Stewart,351
+Beaver County,Beaver 2,U.S. House of Representatives,2,DEM,Jay Seegmiller,60
+Beaver County,Beaver 2,U.S. House of Representatives,2,UNA,Charles E. Kimball,8
+Beaver County,Beaver 2,U.S. House of Representatives,2,CON,Jonathan D. Garrard,13
+Beaver County,Beaver 2,U.S. House of Representatives,2,,Joseph Andrade,5
+Beaver County,Beaver 2,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Beaver 3,U.S. House of Representatives,2,REP,Chris Stewart,271
+Beaver County,Beaver 3,U.S. House of Representatives,2,DEM,Jay Seegmiller,39
+Beaver County,Beaver 3,U.S. House of Representatives,2,UNA,Charles E. Kimball,0
+Beaver County,Beaver 3,U.S. House of Representatives,2,CON,Jonathan D. Garrard,8
+Beaver County,Beaver 3,U.S. House of Representatives,2,,Joseph Andrade,2
+Beaver County,Beaver 3,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Beaver 4,U.S. House of Representatives,2,REP,Chris Stewart,105
+Beaver County,Beaver 4,U.S. House of Representatives,2,DEM,Jay Seegmiller,24
+Beaver County,Beaver 4,U.S. House of Representatives,2,UNA,Charles E. Kimball,1
+Beaver County,Beaver 4,U.S. House of Representatives,2,CON,Jonathan D. Garrard,6
+Beaver County,Beaver 4,U.S. House of Representatives,2,,Joseph Andrade,1
+Beaver County,Beaver 4,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Greenville,U.S. House of Representatives,2,REP,Chris Stewart,89
+Beaver County,Greenville,U.S. House of Representatives,2,DEM,Jay Seegmiller,12
+Beaver County,Greenville,U.S. House of Representatives,2,UNA,Charles E. Kimball,0
+Beaver County,Greenville,U.S. House of Representatives,2,CON,Jonathan D. Garrard,1
+Beaver County,Greenville,U.S. House of Representatives,2,,Joseph Andrade,1
+Beaver County,Greenville,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Milford 1,U.S. House of Representatives,2,REP,Chris Stewart,34
+Beaver County,Milford 1,U.S. House of Representatives,2,DEM,Jay Seegmiller,39
+Beaver County,Milford 1,U.S. House of Representatives,2,UNA,Charles E. Kimball,2
+Beaver County,Milford 1,U.S. House of Representatives,2,CON,Jonathan D. Garrard,0
+Beaver County,Milford 1,U.S. House of Representatives,2,,Joseph Andrade,0
+Beaver County,Milford 1,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Milford 2,U.S. House of Representatives,2,REP,Chris Stewart,206
+Beaver County,Milford 2,U.S. House of Representatives,2,DEM,Jay Seegmiller,159
+Beaver County,Milford 2,U.S. House of Representatives,2,UNA,Charles E. Kimball,7
+Beaver County,Milford 2,U.S. House of Representatives,2,CON,Jonathan D. Garrard,10
+Beaver County,Milford 2,U.S. House of Representatives,2,,Joseph Andrade,1
+Beaver County,Milford 2,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Milford 3,U.S. House of Representatives,2,REP,Chris Stewart,66
+Beaver County,Milford 3,U.S. House of Representatives,2,DEM,Jay Seegmiller,31
+Beaver County,Milford 3,U.S. House of Representatives,2,UNA,Charles E. Kimball,1
+Beaver County,Milford 3,U.S. House of Representatives,2,CON,Jonathan D. Garrard,2
+Beaver County,Milford 3,U.S. House of Representatives,2,,Joseph Andrade,0
+Beaver County,Milford 3,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Minersville,U.S. House of Representatives,2,REP,Chris Stewart,313
+Beaver County,Minersville,U.S. House of Representatives,2,DEM,Jay Seegmiller,33
+Beaver County,Minersville,U.S. House of Representatives,2,UNA,Charles E. Kimball,3
+Beaver County,Minersville,U.S. House of Representatives,2,CON,Jonathan D. Garrard,6
+Beaver County,Minersville,U.S. House of Representatives,2,,Joseph Andrade,1
+Beaver County,Minersville,U.S. House of Representatives,2,,Write-In Votes,0
+Beaver County,Beaver 1,Attorney General,,DEM,Dee W. Smith,65
+Beaver County,Beaver 1,Attorney General,,REP,John Swallow,469
+Beaver County,Beaver 1,Attorney General,,LIB,W. Andrew McCullough,11
+Beaver County,Beaver 1,Attorney General,,,Write-In Votes,0
+Beaver County,Beaver 2,Attorney General,,DEM,Dee W. Smith,69
+Beaver County,Beaver 2,Attorney General,,REP,John Swallow,326
+Beaver County,Beaver 2,Attorney General,,LIB,W. Andrew McCullough,28
+Beaver County,Beaver 2,Attorney General,,,Write-In Votes,0
+Beaver County,Beaver 3,Attorney General,,DEM,Dee W. Smith,37
+Beaver County,Beaver 3,Attorney General,,REP,John Swallow,266
+Beaver County,Beaver 3,Attorney General,,LIB,W. Andrew McCullough,3
+Beaver County,Beaver 3,Attorney General,,,Write-In Votes,0
+Beaver County,Beaver 4,Attorney General,,DEM,Dee W. Smith,24
+Beaver County,Beaver 4,Attorney General,,REP,John Swallow,105
+Beaver County,Beaver 4,Attorney General,,LIB,W. Andrew McCullough,7
+Beaver County,Beaver 4,Attorney General,,,Write-In Votes,0
+Beaver County,Greenville,Attorney General,,DEM,Dee W. Smith,12
+Beaver County,Greenville,Attorney General,,REP,John Swallow,84
+Beaver County,Greenville,Attorney General,,LIB,W. Andrew McCullough,4
+Beaver County,Greenville,Attorney General,,,Write-In Votes,0
+Beaver County,Milford 1,Attorney General,,DEM,Dee W. Smith,37
+Beaver County,Milford 1,Attorney General,,REP,John Swallow,31
+Beaver County,Milford 1,Attorney General,,LIB,W. Andrew McCullough,3
+Beaver County,Milford 1,Attorney General,,,Write-In Votes,0
+Beaver County,Milford 2,Attorney General,,DEM,Dee W. Smith,121
+Beaver County,Milford 2,Attorney General,,REP,John Swallow,222
+Beaver County,Milford 2,Attorney General,,LIB,W. Andrew McCullough,21
+Beaver County,Milford 2,Attorney General,,,Write-In Votes,0
+Beaver County,Milford 3,Attorney General,,DEM,Dee W. Smith,24
+Beaver County,Milford 3,Attorney General,,REP,John Swallow,68
+Beaver County,Milford 3,Attorney General,,LIB,W. Andrew McCullough,5
+Beaver County,Milford 3,Attorney General,,,Write-In Votes,0
+Beaver County,Minersville,Attorney General,,DEM,Dee W. Smith,35
+Beaver County,Minersville,Attorney General,,REP,John Swallow,309
+Beaver County,Minersville,Attorney General,,LIB,W. Andrew McCullough,9
+Beaver County,Minersville,Attorney General,,,Write-In Votes,0
+Beaver County,Beaver 1,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Beaver 1,State Senate,24,CON,Trestin Meacham,
+Beaver County,Beaver 1,State Senate,24,,Write-In Votes,
+Beaver County,Beaver 2,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Beaver 2,State Senate,24,CON,Trestin Meacham,
+Beaver County,Beaver 2,State Senate,24,,Write-In Votes,
+Beaver County,Beaver 3,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Beaver 3,State Senate,24,CON,Trestin Meacham,
+Beaver County,Beaver 3,State Senate,24,,Write-In Votes,
+Beaver County,Beaver 4,State Senate,24,REP,Ralph Okerlund,103
+Beaver County,Beaver 4,State Senate,24,CON,Trestin Meacham,23
+Beaver County,Beaver 4,State Senate,24,,Write-In Votes,0
+Beaver County,Greenville,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Greenville,State Senate,24,CON,Trestin Meacham,
+Beaver County,Greenville,State Senate,24,,Write-In Votes,
+Beaver County,Milford 1,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Milford 1,State Senate,24,CON,Trestin Meacham,
+Beaver County,Milford 1,State Senate,24,,Write-In Votes,
+Beaver County,Milford 2,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Milford 2,State Senate,24,CON,Trestin Meacham,
+Beaver County,Milford 2,State Senate,24,,Write-In Votes,
+Beaver County,Milford 3,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Milford 3,State Senate,24,CON,Trestin Meacham,
+Beaver County,Milford 3,State Senate,24,,Write-In Votes,
+Beaver County,Minersville,State Senate,24,REP,Ralph Okerlund,
+Beaver County,Minersville,State Senate,24,CON,Trestin Meacham,
+Beaver County,Minersville,State Senate,24,,Write-In Votes,
+Beaver County,Beaver 1,State Senate,28,DEM,Geoffrey L. Chesnut,73
+Beaver County,Beaver 1,State Senate,28,REP,Evan J. Vickers,492
+Beaver County,Beaver 1,State Senate,28,,Write-In Votes,2
+Beaver County,Beaver 2,State Senate,28,DEM,Geoffrey L. Chesnut,51
+Beaver County,Beaver 2,State Senate,28,REP,Evan J. Vickers,383
+Beaver County,Beaver 2,State Senate,28,,Write-In Votes,0
+Beaver County,Beaver 3,State Senate,28,DEM,Geoffrey L. Chesnut,29
+Beaver County,Beaver 3,State Senate,28,REP,Evan J. Vickers,287
+Beaver County,Beaver 3,State Senate,28,,Write-In Votes,1
+Beaver County,Beaver 4,State Senate,28,DEM,Geoffrey L. Chesnut,
+Beaver County,Beaver 4,State Senate,28,REP,Evan J. Vickers,
+Beaver County,Beaver 4,State Senate,28,,Write-In Votes,
+Beaver County,Greenville,State Senate,28,DEM,Geoffrey L. Chesnut,9
+Beaver County,Greenville,State Senate,28,REP,Evan J. Vickers,91
+Beaver County,Greenville,State Senate,28,,Write-In Votes,0
+Beaver County,Milford 1,State Senate,28,DEM,Geoffrey L. Chesnut,31
+Beaver County,Milford 1,State Senate,28,REP,Evan J. Vickers,43
+Beaver County,Milford 1,State Senate,28,,Write-In Votes,0
+Beaver County,Milford 2,State Senate,28,DEM,Geoffrey L. Chesnut,112
+Beaver County,Milford 2,State Senate,28,REP,Evan J. Vickers,268
+Beaver County,Milford 2,State Senate,28,,Write-In Votes,4
+Beaver County,Milford 3,State Senate,28,DEM,Geoffrey L. Chesnut,24
+Beaver County,Milford 3,State Senate,28,REP,Evan J. Vickers,77
+Beaver County,Milford 3,State Senate,28,,Write-In Votes,0
+Beaver County,Minersville,State Senate,28,DEM,Geoffrey L. Chesnut,28
+Beaver County,Minersville,State Senate,28,REP,Evan J. Vickers,331
+Beaver County,Minersville,State Senate,28,,Write-In Votes,4
+Beaver County,Beaver 1,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Beaver 1,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Beaver 1,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Beaver 1,State House of Representatives,68,,Write-In Votes,
+Beaver County,Beaver 2,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Beaver 2,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Beaver 2,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Beaver 2,State House of Representatives,68,,Write-In Votes,
+Beaver County,Beaver 3,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Beaver 3,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Beaver 3,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Beaver 3,State House of Representatives,68,,Write-In Votes,
+Beaver County,Beaver 4,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Beaver 4,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Beaver 4,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Beaver 4,State House of Representatives,68,,Write-In Votes,
+Beaver County,Greenville,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Greenville,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Greenville,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Greenville,State House of Representatives,68,,Write-In Votes,
+Beaver County,Milford 1,State House of Representatives,68,REP,Merrill Nelson,34
+Beaver County,Milford 1,State House of Representatives,68,DEM,Thomas E. Nedreberg,35
+Beaver County,Milford 1,State House of Representatives,68,,"Paul McCollaum, Jr.",5
+Beaver County,Milford 1,State House of Representatives,68,,Write-In Votes,0
+Beaver County,Milford 2,State House of Representatives,68,REP,Merrill Nelson,225
+Beaver County,Milford 2,State House of Representatives,68,DEM,Thomas E. Nedreberg,139
+Beaver County,Milford 2,State House of Representatives,68,,"Paul McCollaum, Jr.",13
+Beaver County,Milford 2,State House of Representatives,68,,Write-In Votes,0
+Beaver County,Milford 3,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Milford 3,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Milford 3,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Milford 3,State House of Representatives,68,,Write-In Votes,
+Beaver County,Minersville,State House of Representatives,68,REP,Merrill Nelson,
+Beaver County,Minersville,State House of Representatives,68,DEM,Thomas E. Nedreberg,
+Beaver County,Minersville,State House of Representatives,68,,"Paul McCollaum, Jr.",
+Beaver County,Minersville,State House of Representatives,68,,Write-In Votes,
+Beaver County,Beaver 1,State House of Representatives,73,REP,Micheal Noel,459
+Beaver County,Beaver 1,State House of Representatives,73,JUS,Ty Markham,99
+Beaver County,Beaver 1,State House of Representatives,73,,Write-In Votes,1
+Beaver County,Beaver 2,State House of Representatives,73,REP,Micheal Noel,341
+Beaver County,Beaver 2,State House of Representatives,73,JUS,Ty Markham,83
+Beaver County,Beaver 2,State House of Representatives,73,,Write-In Votes,0
+Beaver County,Beaver 3,State House of Representatives,73,REP,Micheal Noel,246
+Beaver County,Beaver 3,State House of Representatives,73,JUS,Ty Markham,63
+Beaver County,Beaver 3,State House of Representatives,73,,Write-In Votes,2
+Beaver County,Beaver 4,State House of Representatives,73,REP,Micheal Noel,98
+Beaver County,Beaver 4,State House of Representatives,73,JUS,Ty Markham,30
+Beaver County,Beaver 4,State House of Representatives,73,,Write-In Votes,0
+Beaver County,Greenville,State House of Representatives,73,REP,Micheal Noel,74
+Beaver County,Greenville,State House of Representatives,73,JUS,Ty Markham,24
+Beaver County,Greenville,State House of Representatives,73,,Write-In Votes,0
+Beaver County,Milford 1,State House of Representatives,73,REP,Micheal Noel,
+Beaver County,Milford 1,State House of Representatives,73,JUS,Ty Markham,
+Beaver County,Milford 1,State House of Representatives,73,,Write-In Votes,
+Beaver County,Milford 2,State House of Representatives,73,REP,Micheal Noel,
+Beaver County,Milford 2,State House of Representatives,73,JUS,Ty Markham,
+Beaver County,Milford 2,State House of Representatives,73,,Write-In Votes,
+Beaver County,Milford 3,State House of Representatives,73,REP,Micheal Noel,74
+Beaver County,Milford 3,State House of Representatives,73,JUS,Ty Markham,23
+Beaver County,Milford 3,State House of Representatives,73,,Write-In Votes,0
+Beaver County,Minersville,State House of Representatives,73,REP,Micheal Noel,312
+Beaver County,Minersville,State House of Representatives,73,JUS,Ty Markham,40
+Beaver County,Minersville,State House of Representatives,73,,Write-In Votes,1

--- a/2012/20121106__ut__general__beaver__precinct.csv
+++ b/2012/20121106__ut__general__beaver__precinct.csv
@@ -53,6 +53,78 @@ Beaver County,Minersville,Straight Ticket,,Constitution (CON),,0
 Beaver County,Minersville,Straight Ticket,,Justice (JUS),,0
 Beaver County,Minersville,Straight Ticket,,Libertarian (LIB),,0
 Beaver County,Minersville,Straight Ticket,,Green (GRN),,0
+Beaver County,Beaver 1,U.S. President,,GRN,Jill Stein,1
+Beaver County,Beaver 1,U.S. President,,,Gloria La Riva,0
+Beaver County,Beaver 1,U.S. President,,REP,Mitt Romney,530
+Beaver County,Beaver 1,U.S. President,,DEM,Barack Obama,55
+Beaver County,Beaver 1,U.S. President,,LIB,Gary Johnson,0
+Beaver County,Beaver 1,U.S. President,,CON,Virgil Goode,3
+Beaver County,Beaver 1,U.S. President,,JUS,Ross Anderson,4
+Beaver County,Beaver 1,U.S. President,,,Write-In Votes,0
+Beaver County,Beaver 2,U.S. President,,GRN,Jill Stein,2
+Beaver County,Beaver 2,U.S. President,,,Gloria La Riva,0
+Beaver County,Beaver 2,U.S. President,,REP,Mitt Romney,394
+Beaver County,Beaver 2,U.S. President,,DEM,Barack Obama,48
+Beaver County,Beaver 2,U.S. President,,LIB,Gary Johnson,5
+Beaver County,Beaver 2,U.S. President,,CON,Virgil Goode,0
+Beaver County,Beaver 2,U.S. President,,JUS,Ross Anderson,0
+Beaver County,Beaver 2,U.S. President,,,Write-In Votes,2
+Beaver County,Beaver 3,U.S. President,,GRN,Jill Stein,0
+Beaver County,Beaver 3,U.S. President,,,Gloria La Riva,0
+Beaver County,Beaver 3,U.S. President,,REP,Mitt Romney,296
+Beaver County,Beaver 3,U.S. President,,DEM,Barack Obama,33
+Beaver County,Beaver 3,U.S. President,,LIB,Gary Johnson,3
+Beaver County,Beaver 3,U.S. President,,CON,Virgil Goode,2
+Beaver County,Beaver 3,U.S. President,,JUS,Ross Anderson,0
+Beaver County,Beaver 3,U.S. President,,,Write-In Votes,0
+Beaver County,Beaver 4,U.S. President,,GRN,Jill Stein,0
+Beaver County,Beaver 4,U.S. President,,,Gloria La Riva,0
+Beaver County,Beaver 4,U.S. President,,REP,Mitt Romney,117
+Beaver County,Beaver 4,U.S. President,,DEM,Barack Obama,22
+Beaver County,Beaver 4,U.S. President,,LIB,Gary Johnson,0
+Beaver County,Beaver 4,U.S. President,,CON,Virgil Goode,1
+Beaver County,Beaver 4,U.S. President,,JUS,Ross Anderson,0
+Beaver County,Beaver 4,U.S. President,,,Write-In Votes,0
+Beaver County,Greenville,U.S. President,,GRN,Jill Stein,0
+Beaver County,Greenville,U.S. President,,,Gloria La Riva,0
+Beaver County,Greenville,U.S. President,,REP,Mitt Romney,94
+Beaver County,Greenville,U.S. President,,DEM,Barack Obama,13
+Beaver County,Greenville,U.S. President,,LIB,Gary Johnson,1
+Beaver County,Greenville,U.S. President,,CON,Virgil Goode,0
+Beaver County,Greenville,U.S. President,,JUS,Ross Anderson,0
+Beaver County,Greenville,U.S. President,,,Write-In Votes,1
+Beaver County,Milford 1,U.S. President,,GRN,Jill Stein,0
+Beaver County,Milford 1,U.S. President,,,Gloria La Riva,0
+Beaver County,Milford 1,U.S. President,,REP,Mitt Romney,43
+Beaver County,Milford 1,U.S. President,,DEM,Barack Obama,31
+Beaver County,Milford 1,U.S. President,,LIB,Gary Johnson,0
+Beaver County,Milford 1,U.S. President,,CON,Virgil Goode,0
+Beaver County,Milford 1,U.S. President,,JUS,Ross Anderson,1
+Beaver County,Milford 1,U.S. President,,,Write-In Votes,0
+Beaver County,Milford 2,U.S. President,,GRN,Jill Stein,1
+Beaver County,Milford 2,U.S. President,,,Gloria La Riva,0
+Beaver County,Milford 2,U.S. President,,REP,Mitt Romney,276
+Beaver County,Milford 2,U.S. President,,DEM,Barack Obama,108
+Beaver County,Milford 2,U.S. President,,LIB,Gary Johnson,4
+Beaver County,Milford 2,U.S. President,,CON,Virgil Goode,1
+Beaver County,Milford 2,U.S. President,,JUS,Ross Anderson,3
+Beaver County,Milford 2,U.S. President,,,Write-In Votes,0
+Beaver County,Milford 3,U.S. President,,GRN,Jill Stein,0
+Beaver County,Milford 3,U.S. President,,,Gloria La Riva,0
+Beaver County,Milford 3,U.S. President,,REP,Mitt Romney,83
+Beaver County,Milford 3,U.S. President,,DEM,Barack Obama,15
+Beaver County,Milford 3,U.S. President,,LIB,Gary Johnson,3
+Beaver County,Milford 3,U.S. President,,CON,Virgil Goode,1
+Beaver County,Milford 3,U.S. President,,JUS,Ross Anderson,1
+Beaver County,Milford 3,U.S. President,,,Write-In Votes,0
+Beaver County,Minersville,U.S. President,,GRN,Jill Stein,0
+Beaver County,Minersville,U.S. President,,,Gloria La Riva,0
+Beaver County,Minersville,U.S. President,,REP,Mitt Romney,341
+Beaver County,Minersville,U.S. President,,DEM,Barack Obama,21
+Beaver County,Minersville,U.S. President,,LIB,Gary Johnson,1
+Beaver County,Minersville,U.S. President,,CON,Virgil Goode,0
+Beaver County,Minersville,U.S. President,,JUS,Ross Anderson,2
+Beaver County,Minersville,U.S. President,,,Write-In Votes,2
 Beaver County,Beaver 1,U.S. House of Representatives,2,REP,Chris Stewart,491
 Beaver County,Beaver 1,U.S. House of Representatives,2,DEM,Jay Seegmiller,68
 Beaver County,Beaver 1,U.S. House of Representatives,2,UNA,Charles E. Kimball,3

--- a/2012/20121106__ut__general__cache__precinct.csv
+++ b/2012/20121106__ut__general__cache__precinct.csv
@@ -1,0 +1,2495 @@
+county,precinct,office,district,party,candidate,votes
+Cache County,Log01,Straight Ticket,,Constitution (CON),,3
+Cache County,Log01,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log01,Straight Ticket,,Democratic (DEM),,35
+Cache County,Log01,Straight Ticket,,Republican (REP),,88
+Cache County,Log01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log02,Straight Ticket,,Constitution (CON),,3
+Cache County,Log02,Straight Ticket,,Libertarian (LIB),,7
+Cache County,Log02,Straight Ticket,,Democratic (DEM),,59
+Cache County,Log02,Straight Ticket,,Republican (REP),,139
+Cache County,Log02,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log02,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log03,Straight Ticket,,Constitution (CON),,1
+Cache County,Log03,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Log03,Straight Ticket,,Democratic (DEM),,40
+Cache County,Log03,Straight Ticket,,Republican (REP),,180
+Cache County,Log03,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log03,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log04,Straight Ticket,,Constitution (CON),,0
+Cache County,Log04,Straight Ticket,,Libertarian (LIB),,8
+Cache County,Log04,Straight Ticket,,Democratic (DEM),,42
+Cache County,Log04,Straight Ticket,,Republican (REP),,120
+Cache County,Log04,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log04,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log05,Straight Ticket,,Constitution (CON),,4
+Cache County,Log05,Straight Ticket,,Libertarian (LIB),,6
+Cache County,Log05,Straight Ticket,,Democratic (DEM),,82
+Cache County,Log05,Straight Ticket,,Republican (REP),,204
+Cache County,Log05,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log05,Straight Ticket,,Green Party (GRN),,3
+Cache County,Log06,Straight Ticket,,Constitution (CON),,4
+Cache County,Log06,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log06,Straight Ticket,,Democratic (DEM),,62
+Cache County,Log06,Straight Ticket,,Republican (REP),,160
+Cache County,Log06,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log06,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log07,Straight Ticket,,Constitution (CON),,2
+Cache County,Log07,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log07,Straight Ticket,,Democratic (DEM),,28
+Cache County,Log07,Straight Ticket,,Republican (REP),,72
+Cache County,Log07,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log07,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log08,Straight Ticket,,Constitution (CON),,1
+Cache County,Log08,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Log08,Straight Ticket,,Democratic (DEM),,17
+Cache County,Log08,Straight Ticket,,Republican (REP),,60
+Cache County,Log08,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log08,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log09,Straight Ticket,,Constitution (CON),,0
+Cache County,Log09,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Log09,Straight Ticket,,Democratic (DEM),,45
+Cache County,Log09,Straight Ticket,,Republican (REP),,102
+Cache County,Log09,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log09,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log10,Straight Ticket,,Constitution (CON),,2
+Cache County,Log10,Straight Ticket,,Libertarian (LIB),,6
+Cache County,Log10,Straight Ticket,,Democratic (DEM),,24
+Cache County,Log10,Straight Ticket,,Republican (REP),,101
+Cache County,Log10,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log10,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log11,Straight Ticket,,Constitution (CON),,2
+Cache County,Log11,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log11,Straight Ticket,,Democratic (DEM),,24
+Cache County,Log11,Straight Ticket,,Republican (REP),,111
+Cache County,Log11,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log11,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log12,Straight Ticket,,Constitution (CON),,1
+Cache County,Log12,Straight Ticket,,Libertarian (LIB),,8
+Cache County,Log12,Straight Ticket,,Democratic (DEM),,40
+Cache County,Log12,Straight Ticket,,Republican (REP),,125
+Cache County,Log12,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log12,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log13,Straight Ticket,,Constitution (CON),,1
+Cache County,Log13,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log13,Straight Ticket,,Democratic (DEM),,76
+Cache County,Log13,Straight Ticket,,Republican (REP),,158
+Cache County,Log13,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log13,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log14,Straight Ticket,,Constitution (CON),,2
+Cache County,Log14,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log14,Straight Ticket,,Democratic (DEM),,51
+Cache County,Log14,Straight Ticket,,Republican (REP),,123
+Cache County,Log14,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log14,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log15,Straight Ticket,,Constitution (CON),,2
+Cache County,Log15,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log15,Straight Ticket,,Democratic (DEM),,21
+Cache County,Log15,Straight Ticket,,Republican (REP),,157
+Cache County,Log15,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log15,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log16,Straight Ticket,,Constitution (CON),,1
+Cache County,Log16,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log16,Straight Ticket,,Democratic (DEM),,47
+Cache County,Log16,Straight Ticket,,Republican (REP),,136
+Cache County,Log16,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log16,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log17,Straight Ticket,,Constitution (CON),,0
+Cache County,Log17,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Log17,Straight Ticket,,Democratic (DEM),,34
+Cache County,Log17,Straight Ticket,,Republican (REP),,201
+Cache County,Log17,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log17,Straight Ticket,,Green Party (GRN),,3
+Cache County,Log18,Straight Ticket,,Constitution (CON),,0
+Cache County,Log18,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Log18,Straight Ticket,,Democratic (DEM),,4
+Cache County,Log18,Straight Ticket,,Republican (REP),,187
+Cache County,Log18,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log18,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log19,Straight Ticket,,Constitution (CON),,1
+Cache County,Log19,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log19,Straight Ticket,,Democratic (DEM),,24
+Cache County,Log19,Straight Ticket,,Republican (REP),,122
+Cache County,Log19,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log19,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log20,Straight Ticket,,Constitution (CON),,1
+Cache County,Log20,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log20,Straight Ticket,,Democratic (DEM),,42
+Cache County,Log20,Straight Ticket,,Republican (REP),,198
+Cache County,Log20,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log20,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log21,Straight Ticket,,Constitution (CON),,2
+Cache County,Log21,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Log21,Straight Ticket,,Democratic (DEM),,46
+Cache County,Log21,Straight Ticket,,Republican (REP),,99
+Cache County,Log21,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log21,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log22,Straight Ticket,,Constitution (CON),,1
+Cache County,Log22,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log22,Straight Ticket,,Democratic (DEM),,53
+Cache County,Log22,Straight Ticket,,Republican (REP),,211
+Cache County,Log22,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log22,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log23,Straight Ticket,,Constitution (CON),,2
+Cache County,Log23,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Log23,Straight Ticket,,Democratic (DEM),,24
+Cache County,Log23,Straight Ticket,,Republican (REP),,174
+Cache County,Log23,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log23,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log24,Straight Ticket,,Constitution (CON),,0
+Cache County,Log24,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log24,Straight Ticket,,Democratic (DEM),,32
+Cache County,Log24,Straight Ticket,,Republican (REP),,74
+Cache County,Log24,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Log24,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log25,Straight Ticket,,Constitution (CON),,3
+Cache County,Log25,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Log25,Straight Ticket,,Democratic (DEM),,36
+Cache County,Log25,Straight Ticket,,Republican (REP),,161
+Cache County,Log25,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log25,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log26,Straight Ticket,,Constitution (CON),,1
+Cache County,Log26,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log26,Straight Ticket,,Democratic (DEM),,31
+Cache County,Log26,Straight Ticket,,Republican (REP),,169
+Cache County,Log26,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log26,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log27,Straight Ticket,,Constitution (CON),,3
+Cache County,Log27,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Log27,Straight Ticket,,Democratic (DEM),,43
+Cache County,Log27,Straight Ticket,,Republican (REP),,196
+Cache County,Log27,Straight Ticket,,Justice Party (JUS),,2
+Cache County,Log27,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log28,Straight Ticket,,Constitution (CON),,0
+Cache County,Log28,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Log28,Straight Ticket,,Democratic (DEM),,19
+Cache County,Log28,Straight Ticket,,Republican (REP),,84
+Cache County,Log28,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log28,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log29,Straight Ticket,,Constitution (CON),,2
+Cache County,Log29,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log29,Straight Ticket,,Democratic (DEM),,57
+Cache County,Log29,Straight Ticket,,Republican (REP),,185
+Cache County,Log29,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log29,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log30,Straight Ticket,,Constitution (CON),,3
+Cache County,Log30,Straight Ticket,,Libertarian (LIB),,7
+Cache County,Log30,Straight Ticket,,Democratic (DEM),,33
+Cache County,Log30,Straight Ticket,,Republican (REP),,155
+Cache County,Log30,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log30,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log31,Straight Ticket,,Constitution (CON),,3
+Cache County,Log31,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Log31,Straight Ticket,,Democratic (DEM),,42
+Cache County,Log31,Straight Ticket,,Republican (REP),,183
+Cache County,Log31,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log31,Straight Ticket,,Green Party (GRN),,2
+Cache County,Log32,Straight Ticket,,Constitution (CON),,1
+Cache County,Log32,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Log32,Straight Ticket,,Democratic (DEM),,26
+Cache County,Log32,Straight Ticket,,Republican (REP),,102
+Cache County,Log32,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log32,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log33,Straight Ticket,,Constitution (CON),,1
+Cache County,Log33,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Log33,Straight Ticket,,Democratic (DEM),,32
+Cache County,Log33,Straight Ticket,,Republican (REP),,113
+Cache County,Log33,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log33,Straight Ticket,,Green Party (GRN),,0
+Cache County,Log33.5,Straight Ticket,,Constitution (CON),,1
+Cache County,Log33.5,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Log33.5,Straight Ticket,,Democratic (DEM),,12
+Cache County,Log33.5,Straight Ticket,,Republican (REP),,41
+Cache County,Log33.5,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Log33.5,Straight Ticket,,Green Party (GRN),,0
+Cache County,Ama,Straight Ticket,,Constitution (CON),,2
+Cache County,Ama,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Ama,Straight Ticket,,Democratic (DEM),,6
+Cache County,Ama,Straight Ticket,,Republican (REP),,65
+Cache County,Ama,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Ama,Straight Ticket,,Green Party (GRN),,0
+Cache County,Ben,Straight Ticket,,Constitution (CON),,0
+Cache County,Ben,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Ben,Straight Ticket,,Democratic (DEM),,17
+Cache County,Ben,Straight Ticket,,Republican (REP),,122
+Cache County,Ben,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Ben,Straight Ticket,,Green Party (GRN),,0
+Cache County,Clk,Straight Ticket,,Constitution (CON),,2
+Cache County,Clk,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Clk,Straight Ticket,,Democratic (DEM),,6
+Cache County,Clk,Straight Ticket,,Republican (REP),,112
+Cache County,Clk,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Clk,Straight Ticket,,Green Party (GRN),,2
+Cache County,C/Y,Straight Ticket,,Constitution (CON),,2
+Cache County,C/Y,Straight Ticket,,Libertarian (LIB),,2
+Cache County,C/Y,Straight Ticket,,Democratic (DEM),,13
+Cache County,C/Y,Straight Ticket,,Republican (REP),,151
+Cache County,C/Y,Straight Ticket,,Justice Party (JUS),,0
+Cache County,C/Y,Straight Ticket,,Green Party (GRN),,0
+Cache County,Cor,Straight Ticket,,Constitution (CON),,0
+Cache County,Cor,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Cor,Straight Ticket,,Democratic (DEM),,5
+Cache County,Cor,Straight Ticket,,Republican (REP),,45
+Cache County,Cor,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Cor,Straight Ticket,,Green Party (GRN),,0
+Cache County,Cov,Straight Ticket,,Constitution (CON),,1
+Cache County,Cov,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Cov,Straight Ticket,,Democratic (DEM),,12
+Cache County,Cov,Straight Ticket,,Republican (REP),,89
+Cache County,Cov,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Cov,Straight Ticket,,Green Party (GRN),,0
+Cache County,Hyd01,Straight Ticket,,Constitution (CON),,1
+Cache County,Hyd01,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Hyd01,Straight Ticket,,Democratic (DEM),,27
+Cache County,Hyd01,Straight Ticket,,Republican (REP),,265
+Cache County,Hyd01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyd01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Hyd02,Straight Ticket,,Constitution (CON),,1
+Cache County,Hyd02,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Hyd02,Straight Ticket,,Democratic (DEM),,36
+Cache County,Hyd02,Straight Ticket,,Republican (REP),,268
+Cache County,Hyd02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyd02,Straight Ticket,,Green Party (GRN),,0
+Cache County,Hyr01,Straight Ticket,,Constitution (CON),,2
+Cache County,Hyr01,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Hyr01,Straight Ticket,,Democratic (DEM),,37
+Cache County,Hyr01,Straight Ticket,,Republican (REP),,199
+Cache County,Hyr01,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Hyr01,Straight Ticket,,Green Party (GRN),,1
+Cache County,Hyr02,Straight Ticket,,Constitution (CON),,2
+Cache County,Hyr02,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Hyr02,Straight Ticket,,Democratic (DEM),,17
+Cache County,Hyr02,Straight Ticket,,Republican (REP),,116
+Cache County,Hyr02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyr02,Straight Ticket,,Green Party (GRN),,2
+Cache County,Hyr03,Straight Ticket,,Constitution (CON),,2
+Cache County,Hyr03,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Hyr03,Straight Ticket,,Democratic (DEM),,25
+Cache County,Hyr03,Straight Ticket,,Republican (REP),,244
+Cache County,Hyr03,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyr03,Straight Ticket,,Green Party (GRN),,1
+Cache County,Hyr04,Straight Ticket,,Constitution (CON),,0
+Cache County,Hyr04,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Hyr04,Straight Ticket,,Democratic (DEM),,24
+Cache County,Hyr04,Straight Ticket,,Republican (REP),,291
+Cache County,Hyr04,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyr04,Straight Ticket,,Green Party (GRN),,0
+Cache County,Hyr05,Straight Ticket,,Constitution (CON),,2
+Cache County,Hyr05,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Hyr05,Straight Ticket,,Democratic (DEM),,13
+Cache County,Hyr05,Straight Ticket,,Republican (REP),,164
+Cache County,Hyr05,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Hyr05,Straight Ticket,,Green Party (GRN),,0
+Cache County,Lew01,Straight Ticket,,Constitution (CON),,0
+Cache County,Lew01,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Lew01,Straight Ticket,,Democratic (DEM),,24
+Cache County,Lew01,Straight Ticket,,Republican (REP),,178
+Cache County,Lew01,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Lew01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Lew02,Straight Ticket,,Constitution (CON),,3
+Cache County,Lew02,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Lew02,Straight Ticket,,Democratic (DEM),,6
+Cache County,Lew02,Straight Ticket,,Republican (REP),,134
+Cache County,Lew02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Lew02,Straight Ticket,,Green Party (GRN),,0
+Cache County,Men01,Straight Ticket,,Constitution (CON),,0
+Cache County,Men01,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Men01,Straight Ticket,,Democratic (DEM),,2
+Cache County,Men01,Straight Ticket,,Republican (REP),,22
+Cache County,Men01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Men01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Men02,Straight Ticket,,Constitution (CON),,0
+Cache County,Men02,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Men02,Straight Ticket,,Democratic (DEM),,27
+Cache County,Men02,Straight Ticket,,Republican (REP),,315
+Cache County,Men02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Men02,Straight Ticket,,Green Party (GRN),,0
+Cache County,Mil17,Straight Ticket,,Constitution (CON),,0
+Cache County,Mil17,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Mil17,Straight Ticket,,Democratic (DEM),,0
+Cache County,Mil17,Straight Ticket,,Republican (REP),,36
+Cache County,Mil17,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Mil17,Straight Ticket,,Green Party (GRN),,0
+Cache County,Mil25,Straight Ticket,,Constitution (CON),,3
+Cache County,Mil25,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Mil25,Straight Ticket,,Democratic (DEM),,27
+Cache County,Mil25,Straight Ticket,,Republican (REP),,235
+Cache County,Mil25,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Mil25,Straight Ticket,,Green Party (GRN),,0
+Cache County,New,Straight Ticket,,Constitution (CON),,2
+Cache County,New,Straight Ticket,,Libertarian (LIB),,0
+Cache County,New,Straight Ticket,,Democratic (DEM),,16
+Cache County,New,Straight Ticket,,Republican (REP),,142
+Cache County,New,Straight Ticket,,Justice Party (JUS),,0
+Cache County,New,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nib01,Straight Ticket,,Constitution (CON),,1
+Cache County,Nib01,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Nib01,Straight Ticket,,Democratic (DEM),,25
+Cache County,Nib01,Straight Ticket,,Republican (REP),,238
+Cache County,Nib01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nib01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nib03,Straight Ticket,,Constitution (CON),,2
+Cache County,Nib03,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Nib03,Straight Ticket,,Democratic (DEM),,29
+Cache County,Nib03,Straight Ticket,,Republican (REP),,246
+Cache County,Nib03,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Nib03,Straight Ticket,,Green Party (GRN),,2
+Cache County,Nib17,Straight Ticket,,Constitution (CON),,1
+Cache County,Nib17,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Nib17,Straight Ticket,,Democratic (DEM),,25
+Cache County,Nib17,Straight Ticket,,Republican (REP),,193
+Cache County,Nib17,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nib17,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nib25,Straight Ticket,,Constitution (CON),,0
+Cache County,Nib25,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Nib25,Straight Ticket,,Democratic (DEM),,0
+Cache County,Nib25,Straight Ticket,,Republican (REP),,13
+Cache County,Nib25,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nib25,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nlg01,Straight Ticket,,Constitution (CON),,0
+Cache County,Nlg01,Straight Ticket,,Libertarian (LIB),,7
+Cache County,Nlg01,Straight Ticket,,Democratic (DEM),,39
+Cache County,Nlg01,Straight Ticket,,Republican (REP),,160
+Cache County,Nlg01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nlg01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nlg02,Straight Ticket,,Constitution (CON),,3
+Cache County,Nlg02,Straight Ticket,,Libertarian (LIB),,5
+Cache County,Nlg02,Straight Ticket,,Democratic (DEM),,44
+Cache County,Nlg02,Straight Ticket,,Republican (REP),,163
+Cache County,Nlg02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nlg02,Straight Ticket,,Green Party (GRN),,2
+Cache County,Nlg03,Straight Ticket,,Constitution (CON),,3
+Cache County,Nlg03,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Nlg03,Straight Ticket,,Democratic (DEM),,21
+Cache County,Nlg03,Straight Ticket,,Republican (REP),,185
+Cache County,Nlg03,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Nlg03,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nlg04,Straight Ticket,,Constitution (CON),,0
+Cache County,Nlg04,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Nlg04,Straight Ticket,,Democratic (DEM),,28
+Cache County,Nlg04,Straight Ticket,,Republican (REP),,208
+Cache County,Nlg04,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Nlg04,Straight Ticket,,Green Party (GRN),,1
+Cache County,Nlg05,Straight Ticket,,Constitution (CON),,2
+Cache County,Nlg05,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Nlg05,Straight Ticket,,Democratic (DEM),,34
+Cache County,Nlg05,Straight Ticket,,Republican (REP),,216
+Cache County,Nlg05,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Nlg05,Straight Ticket,,Green Party (GRN),,0
+Cache County,Nlg06,Straight Ticket,,Constitution (CON),,1
+Cache County,Nlg06,Straight Ticket,,Libertarian (LIB),,4
+Cache County,Nlg06,Straight Ticket,,Democratic (DEM),,43
+Cache County,Nlg06,Straight Ticket,,Republican (REP),,135
+Cache County,Nlg06,Straight Ticket,,Justice Party (JUS),,2
+Cache County,Nlg06,Straight Ticket,,Green Party (GRN),,0
+Cache County,Par,Straight Ticket,,Constitution (CON),,3
+Cache County,Par,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Par,Straight Ticket,,Democratic (DEM),,24
+Cache County,Par,Straight Ticket,,Republican (REP),,271
+Cache County,Par,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Par,Straight Ticket,,Green Party (GRN),,0
+Cache County,Pro01,Straight Ticket,,Constitution (CON),,1
+Cache County,Pro01,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Pro01,Straight Ticket,,Democratic (DEM),,27
+Cache County,Pro01,Straight Ticket,,Republican (REP),,266
+Cache County,Pro01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Pro01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Pro02,Straight Ticket,,Constitution (CON),,0
+Cache County,Pro02,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Pro02,Straight Ticket,,Democratic (DEM),,53
+Cache County,Pro02,Straight Ticket,,Republican (REP),,315
+Cache County,Pro02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Pro02,Straight Ticket,,Green Party (GRN),,0
+Cache County,Pro03,Straight Ticket,,Constitution (CON),,0
+Cache County,Pro03,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Pro03,Straight Ticket,,Democratic (DEM),,26
+Cache County,Pro03,Straight Ticket,,Republican (REP),,237
+Cache County,Pro03,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Pro03,Straight Ticket,,Green Party (GRN),,0
+Cache County,Pro04,Straight Ticket,,Constitution (CON),,0
+Cache County,Pro04,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Pro04,Straight Ticket,,Democratic (DEM),,34
+Cache County,Pro04,Straight Ticket,,Republican (REP),,231
+Cache County,Pro04,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Pro04,Straight Ticket,,Green Party (GRN),,2
+Cache County,Pro05,Straight Ticket,,Constitution (CON),,0
+Cache County,Pro05,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Pro05,Straight Ticket,,Democratic (DEM),,23
+Cache County,Pro05,Straight Ticket,,Republican (REP),,157
+Cache County,Pro05,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Pro05,Straight Ticket,,Green Party (GRN),,0
+Cache County,Rch01,Straight Ticket,,Constitution (CON),,0
+Cache County,Rch01,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Rch01,Straight Ticket,,Democratic (DEM),,24
+Cache County,Rch01,Straight Ticket,,Republican (REP),,192
+Cache County,Rch01,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Rch01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Rch02,Straight Ticket,,Constitution (CON),,3
+Cache County,Rch02,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Rch02,Straight Ticket,,Democratic (DEM),,28
+Cache County,Rch02,Straight Ticket,,Republican (REP),,216
+Cache County,Rch02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Rch02,Straight Ticket,,Green Party (GRN),,2
+Cache County,Rvh01,Straight Ticket,,Constitution (CON),,0
+Cache County,Rvh01,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Rvh01,Straight Ticket,,Democratic (DEM),,29
+Cache County,Rvh01,Straight Ticket,,Republican (REP),,108
+Cache County,Rvh01,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Rvh01,Straight Ticket,,Green Party (GRN),,1
+Cache County,Rvh02,Straight Ticket,,Constitution (CON),,0
+Cache County,Rvh02,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Rvh02,Straight Ticket,,Democratic (DEM),,31
+Cache County,Rvh02,Straight Ticket,,Republican (REP),,161
+Cache County,Rvh02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Rvh02,Straight Ticket,,Green Party (GRN),,0
+Cache County,Smi01,Straight Ticket,,Constitution (CON),,1
+Cache County,Smi01,Straight Ticket,,Libertarian (LIB),,0
+Cache County,Smi01,Straight Ticket,,Democratic (DEM),,14
+Cache County,Smi01,Straight Ticket,,Republican (REP),,222
+Cache County,Smi01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Smi01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Smi02,Straight Ticket,,Constitution (CON),,1
+Cache County,Smi02,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Smi02,Straight Ticket,,Democratic (DEM),,32
+Cache County,Smi02,Straight Ticket,,Republican (REP),,219
+Cache County,Smi02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Smi02,Straight Ticket,,Green Party (GRN),,1
+Cache County,Smi03,Straight Ticket,,Constitution (CON),,2
+Cache County,Smi03,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Smi03,Straight Ticket,,Democratic (DEM),,20
+Cache County,Smi03,Straight Ticket,,Republican (REP),,220
+Cache County,Smi03,Straight Ticket,,Justice Party (JUS),,2
+Cache County,Smi03,Straight Ticket,,Green Party (GRN),,1
+Cache County,Smi04,Straight Ticket,,Constitution (CON),,3
+Cache County,Smi04,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Smi04,Straight Ticket,,Democratic (DEM),,16
+Cache County,Smi04,Straight Ticket,,Republican (REP),,207
+Cache County,Smi04,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Smi04,Straight Ticket,,Green Party (GRN),,2
+Cache County,Smi05,Straight Ticket,,Constitution (CON),,0
+Cache County,Smi05,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Smi05,Straight Ticket,,Democratic (DEM),,8
+Cache County,Smi05,Straight Ticket,,Republican (REP),,142
+Cache County,Smi05,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Smi05,Straight Ticket,,Green Party (GRN),,0
+Cache County,Smi06,Straight Ticket,,Constitution (CON),,0
+Cache County,Smi06,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Smi06,Straight Ticket,,Democratic (DEM),,17
+Cache County,Smi06,Straight Ticket,,Republican (REP),,212
+Cache County,Smi06,Straight Ticket,,Justice Party (JUS),,1
+Cache County,Smi06,Straight Ticket,,Green Party (GRN),,0
+Cache County,Smi07,Straight Ticket,,Constitution (CON),,1
+Cache County,Smi07,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Smi07,Straight Ticket,,Democratic (DEM),,37
+Cache County,Smi07,Straight Ticket,,Republican (REP),,255
+Cache County,Smi07,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Smi07,Straight Ticket,,Green Party (GRN),,0
+Cache County,Tre,Straight Ticket,,Constitution (CON),,1
+Cache County,Tre,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Tre,Straight Ticket,,Democratic (DEM),,6
+Cache County,Tre,Straight Ticket,,Republican (REP),,81
+Cache County,Tre,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Tre,Straight Ticket,,Green Party (GRN),,0
+Cache County,Wel01,Straight Ticket,,Constitution (CON),,0
+Cache County,Wel01,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Wel01,Straight Ticket,,Democratic (DEM),,7
+Cache County,Wel01,Straight Ticket,,Republican (REP),,143
+Cache County,Wel01,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Wel01,Straight Ticket,,Green Party (GRN),,0
+Cache County,Wel02,Straight Ticket,,Constitution (CON),,1
+Cache County,Wel02,Straight Ticket,,Libertarian (LIB),,1
+Cache County,Wel02,Straight Ticket,,Democratic (DEM),,20
+Cache County,Wel02,Straight Ticket,,Republican (REP),,187
+Cache County,Wel02,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Wel02,Straight Ticket,,Green Party (GRN),,1
+Cache County,Wel03,Straight Ticket,,Constitution (CON),,0
+Cache County,Wel03,Straight Ticket,,Libertarian (LIB),,2
+Cache County,Wel03,Straight Ticket,,Democratic (DEM),,13
+Cache County,Wel03,Straight Ticket,,Republican (REP),,113
+Cache County,Wel03,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Wel03,Straight Ticket,,Green Party (GRN),,1
+Cache County,Wel04,Straight Ticket,,Constitution (CON),,4
+Cache County,Wel04,Straight Ticket,,Libertarian (LIB),,3
+Cache County,Wel04,Straight Ticket,,Democratic (DEM),,13
+Cache County,Wel04,Straight Ticket,,Republican (REP),,193
+Cache County,Wel04,Straight Ticket,,Justice Party (JUS),,0
+Cache County,Wel04,Straight Ticket,,Green Party (GRN),,1
+Cache County,Log01,U.S. President,,GRN,Jill Stein,2
+Cache County,Log01,U.S. President,,,Gloria La Riva,0
+Cache County,Log01,U.S. President,,REP,Mitt Romney,226
+Cache County,Log01,U.S. President,,DEM,Barack Obama,93
+Cache County,Log01,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log01,U.S. President,,CON,Virgil Goode,1
+Cache County,Log01,U.S. President,,JUS,Ross Anderson,5
+Cache County,Log02,U.S. President,,GRN,Jill Stein,3
+Cache County,Log02,U.S. President,,,Gloria La Riva,0
+Cache County,Log02,U.S. President,,REP,Mitt Romney,326
+Cache County,Log02,U.S. President,,DEM,Barack Obama,127
+Cache County,Log02,U.S. President,,LIB,Gary Johnson,12
+Cache County,Log02,U.S. President,,CON,Virgil Goode,0
+Cache County,Log02,U.S. President,,JUS,Ross Anderson,4
+Cache County,Log03,U.S. President,,GRN,Jill Stein,2
+Cache County,Log03,U.S. President,,,Gloria La Riva,0
+Cache County,Log03,U.S. President,,REP,Mitt Romney,422
+Cache County,Log03,U.S. President,,DEM,Barack Obama,117
+Cache County,Log03,U.S. President,,LIB,Gary Johnson,13
+Cache County,Log03,U.S. President,,CON,Virgil Goode,2
+Cache County,Log03,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log04,U.S. President,,GRN,Jill Stein,0
+Cache County,Log04,U.S. President,,,Gloria La Riva,0
+Cache County,Log04,U.S. President,,REP,Mitt Romney,344
+Cache County,Log04,U.S. President,,DEM,Barack Obama,97
+Cache County,Log04,U.S. President,,LIB,Gary Johnson,16
+Cache County,Log04,U.S. President,,CON,Virgil Goode,2
+Cache County,Log04,U.S. President,,JUS,Ross Anderson,2
+Cache County,Log05,U.S. President,,GRN,Jill Stein,7
+Cache County,Log05,U.S. President,,,Gloria La Riva,0
+Cache County,Log05,U.S. President,,REP,Mitt Romney,446
+Cache County,Log05,U.S. President,,DEM,Barack Obama,188
+Cache County,Log05,U.S. President,,LIB,Gary Johnson,5
+Cache County,Log05,U.S. President,,CON,Virgil Goode,7
+Cache County,Log05,U.S. President,,JUS,Ross Anderson,6
+Cache County,Log06,U.S. President,,GRN,Jill Stein,3
+Cache County,Log06,U.S. President,,,Gloria La Riva,0
+Cache County,Log06,U.S. President,,REP,Mitt Romney,347
+Cache County,Log06,U.S. President,,DEM,Barack Obama,114
+Cache County,Log06,U.S. President,,LIB,Gary Johnson,13
+Cache County,Log06,U.S. President,,CON,Virgil Goode,1
+Cache County,Log06,U.S. President,,JUS,Ross Anderson,5
+Cache County,Log07,U.S. President,,GRN,Jill Stein,2
+Cache County,Log07,U.S. President,,,Gloria La Riva,0
+Cache County,Log07,U.S. President,,REP,Mitt Romney,179
+Cache County,Log07,U.S. President,,DEM,Barack Obama,89
+Cache County,Log07,U.S. President,,LIB,Gary Johnson,6
+Cache County,Log07,U.S. President,,CON,Virgil Goode,1
+Cache County,Log07,U.S. President,,JUS,Ross Anderson,2
+Cache County,Log08,U.S. President,,GRN,Jill Stein,0
+Cache County,Log08,U.S. President,,,Gloria La Riva,0
+Cache County,Log08,U.S. President,,REP,Mitt Romney,152
+Cache County,Log08,U.S. President,,DEM,Barack Obama,63
+Cache County,Log08,U.S. President,,LIB,Gary Johnson,12
+Cache County,Log08,U.S. President,,CON,Virgil Goode,2
+Cache County,Log08,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log09,U.S. President,,GRN,Jill Stein,3
+Cache County,Log09,U.S. President,,,Gloria La Riva,0
+Cache County,Log09,U.S. President,,REP,Mitt Romney,260
+Cache County,Log09,U.S. President,,DEM,Barack Obama,113
+Cache County,Log09,U.S. President,,LIB,Gary Johnson,10
+Cache County,Log09,U.S. President,,CON,Virgil Goode,1
+Cache County,Log09,U.S. President,,JUS,Ross Anderson,7
+Cache County,Log10,U.S. President,,GRN,Jill Stein,6
+Cache County,Log10,U.S. President,,,Gloria La Riva,0
+Cache County,Log10,U.S. President,,REP,Mitt Romney,223
+Cache County,Log10,U.S. President,,DEM,Barack Obama,75
+Cache County,Log10,U.S. President,,LIB,Gary Johnson,11
+Cache County,Log10,U.S. President,,CON,Virgil Goode,1
+Cache County,Log10,U.S. President,,JUS,Ross Anderson,3
+Cache County,Log11,U.S. President,,GRN,Jill Stein,1
+Cache County,Log11,U.S. President,,,Gloria La Riva,0
+Cache County,Log11,U.S. President,,REP,Mitt Romney,282
+Cache County,Log11,U.S. President,,DEM,Barack Obama,54
+Cache County,Log11,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log11,U.S. President,,CON,Virgil Goode,1
+Cache County,Log11,U.S. President,,JUS,Ross Anderson,3
+Cache County,Log12,U.S. President,,GRN,Jill Stein,0
+Cache County,Log12,U.S. President,,,Gloria La Riva,0
+Cache County,Log12,U.S. President,,REP,Mitt Romney,232
+Cache County,Log12,U.S. President,,DEM,Barack Obama,93
+Cache County,Log12,U.S. President,,LIB,Gary Johnson,15
+Cache County,Log12,U.S. President,,CON,Virgil Goode,1
+Cache County,Log12,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log13,U.S. President,,GRN,Jill Stein,2
+Cache County,Log13,U.S. President,,,Gloria La Riva,0
+Cache County,Log13,U.S. President,,REP,Mitt Romney,458
+Cache County,Log13,U.S. President,,DEM,Barack Obama,214
+Cache County,Log13,U.S. President,,LIB,Gary Johnson,14
+Cache County,Log13,U.S. President,,CON,Virgil Goode,1
+Cache County,Log13,U.S. President,,JUS,Ross Anderson,4
+Cache County,Log14,U.S. President,,GRN,Jill Stein,5
+Cache County,Log14,U.S. President,,,Gloria La Riva,0
+Cache County,Log14,U.S. President,,REP,Mitt Romney,291
+Cache County,Log14,U.S. President,,DEM,Barack Obama,139
+Cache County,Log14,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log14,U.S. President,,CON,Virgil Goode,1
+Cache County,Log14,U.S. President,,JUS,Ross Anderson,5
+Cache County,Log15,U.S. President,,GRN,Jill Stein,5
+Cache County,Log15,U.S. President,,,Gloria La Riva,1
+Cache County,Log15,U.S. President,,REP,Mitt Romney,363
+Cache County,Log15,U.S. President,,DEM,Barack Obama,57
+Cache County,Log15,U.S. President,,LIB,Gary Johnson,10
+Cache County,Log15,U.S. President,,CON,Virgil Goode,1
+Cache County,Log15,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log16,U.S. President,,GRN,Jill Stein,2
+Cache County,Log16,U.S. President,,,Gloria La Riva,0
+Cache County,Log16,U.S. President,,REP,Mitt Romney,312
+Cache County,Log16,U.S. President,,DEM,Barack Obama,126
+Cache County,Log16,U.S. President,,LIB,Gary Johnson,4
+Cache County,Log16,U.S. President,,CON,Virgil Goode,4
+Cache County,Log16,U.S. President,,JUS,Ross Anderson,4
+Cache County,Log17,U.S. President,,GRN,Jill Stein,4
+Cache County,Log17,U.S. President,,,Gloria La Riva,1
+Cache County,Log17,U.S. President,,REP,Mitt Romney,420
+Cache County,Log17,U.S. President,,DEM,Barack Obama,82
+Cache County,Log17,U.S. President,,LIB,Gary Johnson,16
+Cache County,Log17,U.S. President,,CON,Virgil Goode,1
+Cache County,Log17,U.S. President,,JUS,Ross Anderson,5
+Cache County,Log18,U.S. President,,GRN,Jill Stein,2
+Cache County,Log18,U.S. President,,,Gloria La Riva,0
+Cache County,Log18,U.S. President,,REP,Mitt Romney,402
+Cache County,Log18,U.S. President,,DEM,Barack Obama,25
+Cache County,Log18,U.S. President,,LIB,Gary Johnson,3
+Cache County,Log18,U.S. President,,CON,Virgil Goode,1
+Cache County,Log18,U.S. President,,JUS,Ross Anderson,0
+Cache County,Log19,U.S. President,,GRN,Jill Stein,0
+Cache County,Log19,U.S. President,,,Gloria La Riva,0
+Cache County,Log19,U.S. President,,REP,Mitt Romney,292
+Cache County,Log19,U.S. President,,DEM,Barack Obama,49
+Cache County,Log19,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log19,U.S. President,,CON,Virgil Goode,1
+Cache County,Log19,U.S. President,,JUS,Ross Anderson,0
+Cache County,Log20,U.S. President,,GRN,Jill Stein,4
+Cache County,Log20,U.S. President,,,Gloria La Riva,1
+Cache County,Log20,U.S. President,,REP,Mitt Romney,523
+Cache County,Log20,U.S. President,,DEM,Barack Obama,134
+Cache County,Log20,U.S. President,,LIB,Gary Johnson,4
+Cache County,Log20,U.S. President,,CON,Virgil Goode,1
+Cache County,Log20,U.S. President,,JUS,Ross Anderson,6
+Cache County,Log21,U.S. President,,GRN,Jill Stein,1
+Cache County,Log21,U.S. President,,,Gloria La Riva,0
+Cache County,Log21,U.S. President,,REP,Mitt Romney,264
+Cache County,Log21,U.S. President,,DEM,Barack Obama,147
+Cache County,Log21,U.S. President,,LIB,Gary Johnson,4
+Cache County,Log21,U.S. President,,CON,Virgil Goode,0
+Cache County,Log21,U.S. President,,JUS,Ross Anderson,3
+Cache County,Log22,U.S. President,,GRN,Jill Stein,3
+Cache County,Log22,U.S. President,,,Gloria La Riva,0
+Cache County,Log22,U.S. President,,REP,Mitt Romney,572
+Cache County,Log22,U.S. President,,DEM,Barack Obama,158
+Cache County,Log22,U.S. President,,LIB,Gary Johnson,3
+Cache County,Log22,U.S. President,,CON,Virgil Goode,0
+Cache County,Log22,U.S. President,,JUS,Ross Anderson,3
+Cache County,Log23,U.S. President,,GRN,Jill Stein,3
+Cache County,Log23,U.S. President,,,Gloria La Riva,0
+Cache County,Log23,U.S. President,,REP,Mitt Romney,358
+Cache County,Log23,U.S. President,,DEM,Barack Obama,58
+Cache County,Log23,U.S. President,,LIB,Gary Johnson,14
+Cache County,Log23,U.S. President,,CON,Virgil Goode,3
+Cache County,Log23,U.S. President,,JUS,Ross Anderson,2
+Cache County,Log24,U.S. President,,GRN,Jill Stein,4
+Cache County,Log24,U.S. President,,,Gloria La Riva,0
+Cache County,Log24,U.S. President,,REP,Mitt Romney,177
+Cache County,Log24,U.S. President,,DEM,Barack Obama,78
+Cache County,Log24,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log24,U.S. President,,CON,Virgil Goode,0
+Cache County,Log24,U.S. President,,JUS,Ross Anderson,3
+Cache County,Log25,U.S. President,,GRN,Jill Stein,4
+Cache County,Log25,U.S. President,,,Gloria La Riva,1
+Cache County,Log25,U.S. President,,REP,Mitt Romney,396
+Cache County,Log25,U.S. President,,DEM,Barack Obama,81
+Cache County,Log25,U.S. President,,LIB,Gary Johnson,13
+Cache County,Log25,U.S. President,,CON,Virgil Goode,2
+Cache County,Log25,U.S. President,,JUS,Ross Anderson,4
+Cache County,Log26,U.S. President,,GRN,Jill Stein,5
+Cache County,Log26,U.S. President,,,Gloria La Riva,0
+Cache County,Log26,U.S. President,,REP,Mitt Romney,410
+Cache County,Log26,U.S. President,,DEM,Barack Obama,80
+Cache County,Log26,U.S. President,,LIB,Gary Johnson,6
+Cache County,Log26,U.S. President,,CON,Virgil Goode,2
+Cache County,Log26,U.S. President,,JUS,Ross Anderson,0
+Cache County,Log27,U.S. President,,GRN,Jill Stein,2
+Cache County,Log27,U.S. President,,,Gloria La Riva,0
+Cache County,Log27,U.S. President,,REP,Mitt Romney,433
+Cache County,Log27,U.S. President,,DEM,Barack Obama,65
+Cache County,Log27,U.S. President,,LIB,Gary Johnson,4
+Cache County,Log27,U.S. President,,CON,Virgil Goode,0
+Cache County,Log27,U.S. President,,JUS,Ross Anderson,6
+Cache County,Log28,U.S. President,,GRN,Jill Stein,0
+Cache County,Log28,U.S. President,,,Gloria La Riva,0
+Cache County,Log28,U.S. President,,REP,Mitt Romney,177
+Cache County,Log28,U.S. President,,DEM,Barack Obama,32
+Cache County,Log28,U.S. President,,LIB,Gary Johnson,3
+Cache County,Log28,U.S. President,,CON,Virgil Goode,0
+Cache County,Log28,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log29,U.S. President,,GRN,Jill Stein,4
+Cache County,Log29,U.S. President,,,Gloria La Riva,0
+Cache County,Log29,U.S. President,,REP,Mitt Romney,538
+Cache County,Log29,U.S. President,,DEM,Barack Obama,168
+Cache County,Log29,U.S. President,,LIB,Gary Johnson,6
+Cache County,Log29,U.S. President,,CON,Virgil Goode,3
+Cache County,Log29,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log30,U.S. President,,GRN,Jill Stein,0
+Cache County,Log30,U.S. President,,,Gloria La Riva,0
+Cache County,Log30,U.S. President,,REP,Mitt Romney,417
+Cache County,Log30,U.S. President,,DEM,Barack Obama,76
+Cache County,Log30,U.S. President,,LIB,Gary Johnson,5
+Cache County,Log30,U.S. President,,CON,Virgil Goode,2
+Cache County,Log30,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log31,U.S. President,,GRN,Jill Stein,3
+Cache County,Log31,U.S. President,,,Gloria La Riva,1
+Cache County,Log31,U.S. President,,REP,Mitt Romney,436
+Cache County,Log31,U.S. President,,DEM,Barack Obama,84
+Cache County,Log31,U.S. President,,LIB,Gary Johnson,3
+Cache County,Log31,U.S. President,,CON,Virgil Goode,3
+Cache County,Log31,U.S. President,,JUS,Ross Anderson,2
+Cache County,Log32,U.S. President,,GRN,Jill Stein,1
+Cache County,Log32,U.S. President,,,Gloria La Riva,0
+Cache County,Log32,U.S. President,,REP,Mitt Romney,255
+Cache County,Log32,U.S. President,,DEM,Barack Obama,58
+Cache County,Log32,U.S. President,,LIB,Gary Johnson,4
+Cache County,Log32,U.S. President,,CON,Virgil Goode,1
+Cache County,Log32,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log33,U.S. President,,GRN,Jill Stein,1
+Cache County,Log33,U.S. President,,,Gloria La Riva,0
+Cache County,Log33,U.S. President,,REP,Mitt Romney,323
+Cache County,Log33,U.S. President,,DEM,Barack Obama,87
+Cache County,Log33,U.S. President,,LIB,Gary Johnson,7
+Cache County,Log33,U.S. President,,CON,Virgil Goode,3
+Cache County,Log33,U.S. President,,JUS,Ross Anderson,2
+Cache County,Log33.5,U.S. President,,GRN,Jill Stein,0
+Cache County,Log33.5,U.S. President,,,Gloria La Riva,0
+Cache County,Log33.5,U.S. President,,REP,Mitt Romney,100
+Cache County,Log33.5,U.S. President,,DEM,Barack Obama,21
+Cache County,Log33.5,U.S. President,,LIB,Gary Johnson,0
+Cache County,Log33.5,U.S. President,,CON,Virgil Goode,3
+Cache County,Log33.5,U.S. President,,JUS,Ross Anderson,0
+Cache County,Ama,U.S. President,,GRN,Jill Stein,0
+Cache County,Ama,U.S. President,,,Gloria La Riva,0
+Cache County,Ama,U.S. President,,REP,Mitt Romney,185
+Cache County,Ama,U.S. President,,DEM,Barack Obama,16
+Cache County,Ama,U.S. President,,LIB,Gary Johnson,1
+Cache County,Ama,U.S. President,,CON,Virgil Goode,5
+Cache County,Ama,U.S. President,,JUS,Ross Anderson,4
+Cache County,Ben,U.S. President,,GRN,Jill Stein,2
+Cache County,Ben,U.S. President,,,Gloria La Riva,0
+Cache County,Ben,U.S. President,,REP,Mitt Romney,276
+Cache County,Ben,U.S. President,,DEM,Barack Obama,38
+Cache County,Ben,U.S. President,,LIB,Gary Johnson,1
+Cache County,Ben,U.S. President,,CON,Virgil Goode,0
+Cache County,Ben,U.S. President,,JUS,Ross Anderson,1
+Cache County,Clk,U.S. President,,GRN,Jill Stein,2
+Cache County,Clk,U.S. President,,,Gloria La Riva,1
+Cache County,Clk,U.S. President,,REP,Mitt Romney,305
+Cache County,Clk,U.S. President,,DEM,Barack Obama,20
+Cache County,Clk,U.S. President,,LIB,Gary Johnson,0
+Cache County,Clk,U.S. President,,CON,Virgil Goode,1
+Cache County,Clk,U.S. President,,JUS,Ross Anderson,1
+Cache County,C/Y,U.S. President,,GRN,Jill Stein,2
+Cache County,C/Y,U.S. President,,,Gloria La Riva,1
+Cache County,C/Y,U.S. President,,REP,Mitt Romney,385
+Cache County,C/Y,U.S. President,,DEM,Barack Obama,27
+Cache County,C/Y,U.S. President,,LIB,Gary Johnson,8
+Cache County,C/Y,U.S. President,,CON,Virgil Goode,4
+Cache County,C/Y,U.S. President,,JUS,Ross Anderson,0
+Cache County,Cor,U.S. President,,GRN,Jill Stein,0
+Cache County,Cor,U.S. President,,,Gloria La Riva,0
+Cache County,Cor,U.S. President,,REP,Mitt Romney,113
+Cache County,Cor,U.S. President,,DEM,Barack Obama,7
+Cache County,Cor,U.S. President,,LIB,Gary Johnson,0
+Cache County,Cor,U.S. President,,CON,Virgil Goode,0
+Cache County,Cor,U.S. President,,JUS,Ross Anderson,0
+Cache County,Cov,U.S. President,,GRN,Jill Stein,0
+Cache County,Cov,U.S. President,,,Gloria La Riva,0
+Cache County,Cov,U.S. President,,REP,Mitt Romney,215
+Cache County,Cov,U.S. President,,DEM,Barack Obama,22
+Cache County,Cov,U.S. President,,LIB,Gary Johnson,3
+Cache County,Cov,U.S. President,,CON,Virgil Goode,0
+Cache County,Cov,U.S. President,,JUS,Ross Anderson,0
+Cache County,Hyd01,U.S. President,,GRN,Jill Stein,0
+Cache County,Hyd01,U.S. President,,,Gloria La Riva,0
+Cache County,Hyd01,U.S. President,,REP,Mitt Romney,892
+Cache County,Hyd01,U.S. President,,DEM,Barack Obama,106
+Cache County,Hyd01,U.S. President,,LIB,Gary Johnson,9
+Cache County,Hyd01,U.S. President,,CON,Virgil Goode,2
+Cache County,Hyd01,U.S. President,,JUS,Ross Anderson,2
+Cache County,Hyd02,U.S. President,,GRN,Jill Stein,2
+Cache County,Hyd02,U.S. President,,,Gloria La Riva,0
+Cache County,Hyd02,U.S. President,,REP,Mitt Romney,745
+Cache County,Hyd02,U.S. President,,DEM,Barack Obama,103
+Cache County,Hyd02,U.S. President,,LIB,Gary Johnson,13
+Cache County,Hyd02,U.S. President,,CON,Virgil Goode,3
+Cache County,Hyd02,U.S. President,,JUS,Ross Anderson,5
+Cache County,Hyr01,U.S. President,,GRN,Jill Stein,4
+Cache County,Hyr01,U.S. President,,,Gloria La Riva,1
+Cache County,Hyr01,U.S. President,,REP,Mitt Romney,471
+Cache County,Hyr01,U.S. President,,DEM,Barack Obama,84
+Cache County,Hyr01,U.S. President,,LIB,Gary Johnson,9
+Cache County,Hyr01,U.S. President,,CON,Virgil Goode,6
+Cache County,Hyr01,U.S. President,,JUS,Ross Anderson,4
+Cache County,Hyr02,U.S. President,,GRN,Jill Stein,0
+Cache County,Hyr02,U.S. President,,,Gloria La Riva,0
+Cache County,Hyr02,U.S. President,,REP,Mitt Romney,276
+Cache County,Hyr02,U.S. President,,DEM,Barack Obama,33
+Cache County,Hyr02,U.S. President,,LIB,Gary Johnson,3
+Cache County,Hyr02,U.S. President,,CON,Virgil Goode,0
+Cache County,Hyr02,U.S. President,,JUS,Ross Anderson,0
+Cache County,Hyr03,U.S. President,,GRN,Jill Stein,2
+Cache County,Hyr03,U.S. President,,,Gloria La Riva,0
+Cache County,Hyr03,U.S. President,,REP,Mitt Romney,570
+Cache County,Hyr03,U.S. President,,DEM,Barack Obama,59
+Cache County,Hyr03,U.S. President,,LIB,Gary Johnson,6
+Cache County,Hyr03,U.S. President,,CON,Virgil Goode,1
+Cache County,Hyr03,U.S. President,,JUS,Ross Anderson,1
+Cache County,Hyr04,U.S. President,,GRN,Jill Stein,1
+Cache County,Hyr04,U.S. President,,,Gloria La Riva,0
+Cache County,Hyr04,U.S. President,,REP,Mitt Romney,645
+Cache County,Hyr04,U.S. President,,DEM,Barack Obama,63
+Cache County,Hyr04,U.S. President,,LIB,Gary Johnson,8
+Cache County,Hyr04,U.S. President,,CON,Virgil Goode,1
+Cache County,Hyr04,U.S. President,,JUS,Ross Anderson,1
+Cache County,Hyr05,U.S. President,,GRN,Jill Stein,1
+Cache County,Hyr05,U.S. President,,,Gloria La Riva,0
+Cache County,Hyr05,U.S. President,,REP,Mitt Romney,427
+Cache County,Hyr05,U.S. President,,DEM,Barack Obama,38
+Cache County,Hyr05,U.S. President,,LIB,Gary Johnson,3
+Cache County,Hyr05,U.S. President,,CON,Virgil Goode,1
+Cache County,Hyr05,U.S. President,,JUS,Ross Anderson,1
+Cache County,Lew01,U.S. President,,GRN,Jill Stein,0
+Cache County,Lew01,U.S. President,,,Gloria La Riva,0
+Cache County,Lew01,U.S. President,,REP,Mitt Romney,431
+Cache County,Lew01,U.S. President,,DEM,Barack Obama,41
+Cache County,Lew01,U.S. President,,LIB,Gary Johnson,3
+Cache County,Lew01,U.S. President,,CON,Virgil Goode,0
+Cache County,Lew01,U.S. President,,JUS,Ross Anderson,1
+Cache County,Lew02,U.S. President,,GRN,Jill Stein,0
+Cache County,Lew02,U.S. President,,,Gloria La Riva,0
+Cache County,Lew02,U.S. President,,REP,Mitt Romney,261
+Cache County,Lew02,U.S. President,,DEM,Barack Obama,20
+Cache County,Lew02,U.S. President,,LIB,Gary Johnson,2
+Cache County,Lew02,U.S. President,,CON,Virgil Goode,3
+Cache County,Lew02,U.S. President,,JUS,Ross Anderson,0
+Cache County,Men01,U.S. President,,GRN,Jill Stein,0
+Cache County,Men01,U.S. President,,,Gloria La Riva,0
+Cache County,Men01,U.S. President,,REP,Mitt Romney,60
+Cache County,Men01,U.S. President,,DEM,Barack Obama,12
+Cache County,Men01,U.S. President,,LIB,Gary Johnson,1
+Cache County,Men01,U.S. President,,CON,Virgil Goode,1
+Cache County,Men01,U.S. President,,JUS,Ross Anderson,0
+Cache County,Men02,U.S. President,,GRN,Jill Stein,5
+Cache County,Men02,U.S. President,,,Gloria La Riva,0
+Cache County,Men02,U.S. President,,REP,Mitt Romney,767
+Cache County,Men02,U.S. President,,DEM,Barack Obama,93
+Cache County,Men02,U.S. President,,LIB,Gary Johnson,14
+Cache County,Men02,U.S. President,,CON,Virgil Goode,0
+Cache County,Men02,U.S. President,,JUS,Ross Anderson,1
+Cache County,Mil17,U.S. President,,GRN,Jill Stein,2
+Cache County,Mil17,U.S. President,,,Gloria La Riva,0
+Cache County,Mil17,U.S. President,,REP,Mitt Romney,90
+Cache County,Mil17,U.S. President,,DEM,Barack Obama,11
+Cache County,Mil17,U.S. President,,LIB,Gary Johnson,0
+Cache County,Mil17,U.S. President,,CON,Virgil Goode,0
+Cache County,Mil17,U.S. President,,JUS,Ross Anderson,1
+Cache County,Mil25,U.S. President,,GRN,Jill Stein,0
+Cache County,Mil25,U.S. President,,,Gloria La Riva,0
+Cache County,Mil25,U.S. President,,REP,Mitt Romney,665
+Cache County,Mil25,U.S. President,,DEM,Barack Obama,83
+Cache County,Mil25,U.S. President,,LIB,Gary Johnson,4
+Cache County,Mil25,U.S. President,,CON,Virgil Goode,2
+Cache County,Mil25,U.S. President,,JUS,Ross Anderson,1
+Cache County,New,U.S. President,,GRN,Jill Stein,0
+Cache County,New,U.S. President,,,Gloria La Riva,0
+Cache County,New,U.S. President,,REP,Mitt Romney,385
+Cache County,New,U.S. President,,DEM,Barack Obama,31
+Cache County,New,U.S. President,,LIB,Gary Johnson,2
+Cache County,New,U.S. President,,CON,Virgil Goode,1
+Cache County,New,U.S. President,,JUS,Ross Anderson,1
+Cache County,Nib01,U.S. President,,GRN,Jill Stein,0
+Cache County,Nib01,U.S. President,,,Gloria La Riva,0
+Cache County,Nib01,U.S. President,,REP,Mitt Romney,587
+Cache County,Nib01,U.S. President,,DEM,Barack Obama,56
+Cache County,Nib01,U.S. President,,LIB,Gary Johnson,12
+Cache County,Nib01,U.S. President,,CON,Virgil Goode,7
+Cache County,Nib01,U.S. President,,JUS,Ross Anderson,0
+Cache County,Nib03,U.S. President,,GRN,Jill Stein,1
+Cache County,Nib03,U.S. President,,,Gloria La Riva,1
+Cache County,Nib03,U.S. President,,REP,Mitt Romney,693
+Cache County,Nib03,U.S. President,,DEM,Barack Obama,86
+Cache County,Nib03,U.S. President,,LIB,Gary Johnson,8
+Cache County,Nib03,U.S. President,,CON,Virgil Goode,0
+Cache County,Nib03,U.S. President,,JUS,Ross Anderson,3
+Cache County,Nib17,U.S. President,,GRN,Jill Stein,0
+Cache County,Nib17,U.S. President,,,Gloria La Riva,0
+Cache County,Nib17,U.S. President,,REP,Mitt Romney,522
+Cache County,Nib17,U.S. President,,DEM,Barack Obama,60
+Cache County,Nib17,U.S. President,,LIB,Gary Johnson,5
+Cache County,Nib17,U.S. President,,CON,Virgil Goode,1
+Cache County,Nib17,U.S. President,,JUS,Ross Anderson,3
+Cache County,Nib25,U.S. President,,GRN,Jill Stein,0
+Cache County,Nib25,U.S. President,,,Gloria La Riva,0
+Cache County,Nib25,U.S. President,,REP,Mitt Romney,20
+Cache County,Nib25,U.S. President,,DEM,Barack Obama,0
+Cache County,Nib25,U.S. President,,LIB,Gary Johnson,0
+Cache County,Nib25,U.S. President,,CON,Virgil Goode,0
+Cache County,Nib25,U.S. President,,JUS,Ross Anderson,0
+Cache County,Nlg01,U.S. President,,GRN,Jill Stein,2
+Cache County,Nlg01,U.S. President,,,Gloria La Riva,1
+Cache County,Nlg01,U.S. President,,REP,Mitt Romney,426
+Cache County,Nlg01,U.S. President,,DEM,Barack Obama,101
+Cache County,Nlg01,U.S. President,,LIB,Gary Johnson,11
+Cache County,Nlg01,U.S. President,,CON,Virgil Goode,0
+Cache County,Nlg01,U.S. President,,JUS,Ross Anderson,3
+Cache County,Nlg02,U.S. President,,GRN,Jill Stein,3
+Cache County,Nlg02,U.S. President,,,Gloria La Riva,1
+Cache County,Nlg02,U.S. President,,REP,Mitt Romney,423
+Cache County,Nlg02,U.S. President,,DEM,Barack Obama,88
+Cache County,Nlg02,U.S. President,,LIB,Gary Johnson,5
+Cache County,Nlg02,U.S. President,,CON,Virgil Goode,0
+Cache County,Nlg02,U.S. President,,JUS,Ross Anderson,5
+Cache County,Nlg03,U.S. President,,GRN,Jill Stein,1
+Cache County,Nlg03,U.S. President,,,Gloria La Riva,1
+Cache County,Nlg03,U.S. President,,REP,Mitt Romney,486
+Cache County,Nlg03,U.S. President,,DEM,Barack Obama,71
+Cache County,Nlg03,U.S. President,,LIB,Gary Johnson,2
+Cache County,Nlg03,U.S. President,,CON,Virgil Goode,5
+Cache County,Nlg03,U.S. President,,JUS,Ross Anderson,1
+Cache County,Nlg04,U.S. President,,GRN,Jill Stein,1
+Cache County,Nlg04,U.S. President,,,Gloria La Riva,0
+Cache County,Nlg04,U.S. President,,REP,Mitt Romney,542
+Cache County,Nlg04,U.S. President,,DEM,Barack Obama,84
+Cache County,Nlg04,U.S. President,,LIB,Gary Johnson,8
+Cache County,Nlg04,U.S. President,,CON,Virgil Goode,0
+Cache County,Nlg04,U.S. President,,JUS,Ross Anderson,1
+Cache County,Nlg05,U.S. President,,GRN,Jill Stein,0
+Cache County,Nlg05,U.S. President,,,Gloria La Riva,0
+Cache County,Nlg05,U.S. President,,REP,Mitt Romney,578
+Cache County,Nlg05,U.S. President,,DEM,Barack Obama,107
+Cache County,Nlg05,U.S. President,,LIB,Gary Johnson,12
+Cache County,Nlg05,U.S. President,,CON,Virgil Goode,1
+Cache County,Nlg05,U.S. President,,JUS,Ross Anderson,4
+Cache County,Nlg06,U.S. President,,GRN,Jill Stein,1
+Cache County,Nlg06,U.S. President,,,Gloria La Riva,0
+Cache County,Nlg06,U.S. President,,REP,Mitt Romney,434
+Cache County,Nlg06,U.S. President,,DEM,Barack Obama,130
+Cache County,Nlg06,U.S. President,,LIB,Gary Johnson,6
+Cache County,Nlg06,U.S. President,,CON,Virgil Goode,4
+Cache County,Nlg06,U.S. President,,JUS,Ross Anderson,2
+Cache County,Par,U.S. President,,GRN,Jill Stein,0
+Cache County,Par,U.S. President,,,Gloria La Riva,0
+Cache County,Par,U.S. President,,REP,Mitt Romney,689
+Cache County,Par,U.S. President,,DEM,Barack Obama,73
+Cache County,Par,U.S. President,,LIB,Gary Johnson,7
+Cache County,Par,U.S. President,,CON,Virgil Goode,4
+Cache County,Par,U.S. President,,JUS,Ross Anderson,0
+Cache County,Pro01,U.S. President,,GRN,Jill Stein,1
+Cache County,Pro01,U.S. President,,,Gloria La Riva,0
+Cache County,Pro01,U.S. President,,REP,Mitt Romney,602
+Cache County,Pro01,U.S. President,,DEM,Barack Obama,72
+Cache County,Pro01,U.S. President,,LIB,Gary Johnson,8
+Cache County,Pro01,U.S. President,,CON,Virgil Goode,1
+Cache County,Pro01,U.S. President,,JUS,Ross Anderson,2
+Cache County,Pro02,U.S. President,,GRN,Jill Stein,1
+Cache County,Pro02,U.S. President,,,Gloria La Riva,0
+Cache County,Pro02,U.S. President,,REP,Mitt Romney,782
+Cache County,Pro02,U.S. President,,DEM,Barack Obama,119
+Cache County,Pro02,U.S. President,,LIB,Gary Johnson,9
+Cache County,Pro02,U.S. President,,CON,Virgil Goode,0
+Cache County,Pro02,U.S. President,,JUS,Ross Anderson,0
+Cache County,Pro03,U.S. President,,GRN,Jill Stein,0
+Cache County,Pro03,U.S. President,,,Gloria La Riva,0
+Cache County,Pro03,U.S. President,,REP,Mitt Romney,573
+Cache County,Pro03,U.S. President,,DEM,Barack Obama,69
+Cache County,Pro03,U.S. President,,LIB,Gary Johnson,9
+Cache County,Pro03,U.S. President,,CON,Virgil Goode,0
+Cache County,Pro03,U.S. President,,JUS,Ross Anderson,2
+Cache County,Pro04,U.S. President,,GRN,Jill Stein,2
+Cache County,Pro04,U.S. President,,,Gloria La Riva,0
+Cache County,Pro04,U.S. President,,REP,Mitt Romney,498
+Cache County,Pro04,U.S. President,,DEM,Barack Obama,83
+Cache County,Pro04,U.S. President,,LIB,Gary Johnson,13
+Cache County,Pro04,U.S. President,,CON,Virgil Goode,4
+Cache County,Pro04,U.S. President,,JUS,Ross Anderson,2
+Cache County,Pro05,U.S. President,,GRN,Jill Stein,0
+Cache County,Pro05,U.S. President,,,Gloria La Riva,0
+Cache County,Pro05,U.S. President,,REP,Mitt Romney,409
+Cache County,Pro05,U.S. President,,DEM,Barack Obama,62
+Cache County,Pro05,U.S. President,,LIB,Gary Johnson,2
+Cache County,Pro05,U.S. President,,CON,Virgil Goode,0
+Cache County,Pro05,U.S. President,,JUS,Ross Anderson,2
+Cache County,Rch01,U.S. President,,GRN,Jill Stein,1
+Cache County,Rch01,U.S. President,,,Gloria La Riva,0
+Cache County,Rch01,U.S. President,,REP,Mitt Romney,442
+Cache County,Rch01,U.S. President,,DEM,Barack Obama,59
+Cache County,Rch01,U.S. President,,LIB,Gary Johnson,1
+Cache County,Rch01,U.S. President,,CON,Virgil Goode,0
+Cache County,Rch01,U.S. President,,JUS,Ross Anderson,5
+Cache County,Rch02,U.S. President,,GRN,Jill Stein,1
+Cache County,Rch02,U.S. President,,,Gloria La Riva,0
+Cache County,Rch02,U.S. President,,REP,Mitt Romney,485
+Cache County,Rch02,U.S. President,,DEM,Barack Obama,51
+Cache County,Rch02,U.S. President,,LIB,Gary Johnson,7
+Cache County,Rch02,U.S. President,,CON,Virgil Goode,3
+Cache County,Rch02,U.S. President,,JUS,Ross Anderson,1
+Cache County,Rvh01,U.S. President,,GRN,Jill Stein,1
+Cache County,Rvh01,U.S. President,,,Gloria La Riva,0
+Cache County,Rvh01,U.S. President,,REP,Mitt Romney,292
+Cache County,Rvh01,U.S. President,,DEM,Barack Obama,72
+Cache County,Rvh01,U.S. President,,LIB,Gary Johnson,1
+Cache County,Rvh01,U.S. President,,CON,Virgil Goode,0
+Cache County,Rvh01,U.S. President,,JUS,Ross Anderson,4
+Cache County,Rvh02,U.S. President,,GRN,Jill Stein,1
+Cache County,Rvh02,U.S. President,,,Gloria La Riva,0
+Cache County,Rvh02,U.S. President,,REP,Mitt Romney,420
+Cache County,Rvh02,U.S. President,,DEM,Barack Obama,70
+Cache County,Rvh02,U.S. President,,LIB,Gary Johnson,4
+Cache County,Rvh02,U.S. President,,CON,Virgil Goode,3
+Cache County,Rvh02,U.S. President,,JUS,Ross Anderson,2
+Cache County,Smi01,U.S. President,,GRN,Jill Stein,2
+Cache County,Smi01,U.S. President,,,Gloria La Riva,0
+Cache County,Smi01,U.S. President,,REP,Mitt Romney,516
+Cache County,Smi01,U.S. President,,DEM,Barack Obama,39
+Cache County,Smi01,U.S. President,,LIB,Gary Johnson,5
+Cache County,Smi01,U.S. President,,CON,Virgil Goode,1
+Cache County,Smi01,U.S. President,,JUS,Ross Anderson,0
+Cache County,Smi02,U.S. President,,GRN,Jill Stein,1
+Cache County,Smi02,U.S. President,,,Gloria La Riva,0
+Cache County,Smi02,U.S. President,,REP,Mitt Romney,537
+Cache County,Smi02,U.S. President,,DEM,Barack Obama,100
+Cache County,Smi02,U.S. President,,LIB,Gary Johnson,6
+Cache County,Smi02,U.S. President,,CON,Virgil Goode,0
+Cache County,Smi02,U.S. President,,JUS,Ross Anderson,1
+Cache County,Smi03,U.S. President,,GRN,Jill Stein,1
+Cache County,Smi03,U.S. President,,,Gloria La Riva,1
+Cache County,Smi03,U.S. President,,REP,Mitt Romney,578
+Cache County,Smi03,U.S. President,,DEM,Barack Obama,62
+Cache County,Smi03,U.S. President,,LIB,Gary Johnson,6
+Cache County,Smi03,U.S. President,,CON,Virgil Goode,3
+Cache County,Smi03,U.S. President,,JUS,Ross Anderson,4
+Cache County,Smi04,U.S. President,,GRN,Jill Stein,0
+Cache County,Smi04,U.S. President,,,Gloria La Riva,0
+Cache County,Smi04,U.S. President,,REP,Mitt Romney,569
+Cache County,Smi04,U.S. President,,DEM,Barack Obama,52
+Cache County,Smi04,U.S. President,,LIB,Gary Johnson,1
+Cache County,Smi04,U.S. President,,CON,Virgil Goode,3
+Cache County,Smi04,U.S. President,,JUS,Ross Anderson,0
+Cache County,Smi05,U.S. President,,GRN,Jill Stein,1
+Cache County,Smi05,U.S. President,,,Gloria La Riva,0
+Cache County,Smi05,U.S. President,,REP,Mitt Romney,431
+Cache County,Smi05,U.S. President,,DEM,Barack Obama,39
+Cache County,Smi05,U.S. President,,LIB,Gary Johnson,7
+Cache County,Smi05,U.S. President,,CON,Virgil Goode,3
+Cache County,Smi05,U.S. President,,JUS,Ross Anderson,1
+Cache County,Smi06,U.S. President,,GRN,Jill Stein,0
+Cache County,Smi06,U.S. President,,,Gloria La Riva,0
+Cache County,Smi06,U.S. President,,REP,Mitt Romney,539
+Cache County,Smi06,U.S. President,,DEM,Barack Obama,52
+Cache County,Smi06,U.S. President,,LIB,Gary Johnson,7
+Cache County,Smi06,U.S. President,,CON,Virgil Goode,3
+Cache County,Smi06,U.S. President,,JUS,Ross Anderson,1
+Cache County,Smi07,U.S. President,,GRN,Jill Stein,2
+Cache County,Smi07,U.S. President,,,Gloria La Riva,1
+Cache County,Smi07,U.S. President,,REP,Mitt Romney,622
+Cache County,Smi07,U.S. President,,DEM,Barack Obama,81
+Cache County,Smi07,U.S. President,,LIB,Gary Johnson,5
+Cache County,Smi07,U.S. President,,CON,Virgil Goode,0
+Cache County,Smi07,U.S. President,,JUS,Ross Anderson,2
+Cache County,Tre,U.S. President,,GRN,Jill Stein,1
+Cache County,Tre,U.S. President,,,Gloria La Riva,0
+Cache County,Tre,U.S. President,,REP,Mitt Romney,201
+Cache County,Tre,U.S. President,,DEM,Barack Obama,12
+Cache County,Tre,U.S. President,,LIB,Gary Johnson,1
+Cache County,Tre,U.S. President,,CON,Virgil Goode,2
+Cache County,Tre,U.S. President,,JUS,Ross Anderson,0
+Cache County,Wel01,U.S. President,,GRN,Jill Stein,0
+Cache County,Wel01,U.S. President,,,Gloria La Riva,0
+Cache County,Wel01,U.S. President,,REP,Mitt Romney,356
+Cache County,Wel01,U.S. President,,DEM,Barack Obama,24
+Cache County,Wel01,U.S. President,,LIB,Gary Johnson,3
+Cache County,Wel01,U.S. President,,CON,Virgil Goode,0
+Cache County,Wel01,U.S. President,,JUS,Ross Anderson,1
+Cache County,Wel02,U.S. President,,GRN,Jill Stein,2
+Cache County,Wel02,U.S. President,,,Gloria La Riva,0
+Cache County,Wel02,U.S. President,,REP,Mitt Romney,475
+Cache County,Wel02,U.S. President,,DEM,Barack Obama,47
+Cache County,Wel02,U.S. President,,LIB,Gary Johnson,6
+Cache County,Wel02,U.S. President,,CON,Virgil Goode,6
+Cache County,Wel02,U.S. President,,JUS,Ross Anderson,0
+Cache County,Wel03,U.S. President,,GRN,Jill Stein,2
+Cache County,Wel03,U.S. President,,,Gloria La Riva,1
+Cache County,Wel03,U.S. President,,REP,Mitt Romney,326
+Cache County,Wel03,U.S. President,,DEM,Barack Obama,29
+Cache County,Wel03,U.S. President,,LIB,Gary Johnson,1
+Cache County,Wel03,U.S. President,,CON,Virgil Goode,1
+Cache County,Wel03,U.S. President,,JUS,Ross Anderson,0
+Cache County,Wel04,U.S. President,,GRN,Jill Stein,2
+Cache County,Wel04,U.S. President,,,Gloria La Riva,0
+Cache County,Wel04,U.S. President,,REP,Mitt Romney,466
+Cache County,Wel04,U.S. President,,DEM,Barack Obama,45
+Cache County,Wel04,U.S. President,,LIB,Gary Johnson,4
+Cache County,Wel04,U.S. President,,CON,Virgil Goode,3
+Cache County,Wel04,U.S. President,,JUS,Ross Anderson,1
+Cache County,Log01,U.S. House of Representatives,1,CON,Sherry Phipps,24
+Cache County,Log01,U.S. House of Representatives,1,DEM,Donna McAleer,105
+Cache County,Log01,U.S. House of Representatives,1,REP,Rob Bishop,202
+Cache County,Log02,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Log02,U.S. House of Representatives,1,DEM,Donna McAleer,146
+Cache County,Log02,U.S. House of Representatives,1,REP,Rob Bishop,294
+Cache County,Log03,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Log03,U.S. House of Representatives,1,DEM,Donna McAleer,133
+Cache County,Log03,U.S. House of Representatives,1,REP,Rob Bishop,394
+Cache County,Log04,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Log04,U.S. House of Representatives,1,DEM,Donna McAleer,110
+Cache County,Log04,U.S. House of Representatives,1,REP,Rob Bishop,319
+Cache County,Log05,U.S. House of Representatives,1,CON,Sherry Phipps,25
+Cache County,Log05,U.S. House of Representatives,1,DEM,Donna McAleer,222
+Cache County,Log05,U.S. House of Representatives,1,REP,Rob Bishop,405
+Cache County,Log06,U.S. House of Representatives,1,CON,Sherry Phipps,26
+Cache County,Log06,U.S. House of Representatives,1,DEM,Donna McAleer,128
+Cache County,Log06,U.S. House of Representatives,1,REP,Rob Bishop,313
+Cache County,Log07,U.S. House of Representatives,1,CON,Sherry Phipps,10
+Cache County,Log07,U.S. House of Representatives,1,DEM,Donna McAleer,88
+Cache County,Log07,U.S. House of Representatives,1,REP,Rob Bishop,174
+Cache County,Log08,U.S. House of Representatives,1,CON,Sherry Phipps,9
+Cache County,Log08,U.S. House of Representatives,1,DEM,Donna McAleer,70
+Cache County,Log08,U.S. House of Representatives,1,REP,Rob Bishop,143
+Cache County,Log09,U.S. House of Representatives,1,CON,Sherry Phipps,10
+Cache County,Log09,U.S. House of Representatives,1,DEM,Donna McAleer,143
+Cache County,Log09,U.S. House of Representatives,1,REP,Rob Bishop,228
+Cache County,Log10,U.S. House of Representatives,1,CON,Sherry Phipps,9
+Cache County,Log10,U.S. House of Representatives,1,DEM,Donna McAleer,87
+Cache County,Log10,U.S. House of Representatives,1,REP,Rob Bishop,211
+Cache County,Log11,U.S. House of Representatives,1,CON,Sherry Phipps,20
+Cache County,Log11,U.S. House of Representatives,1,DEM,Donna McAleer,76
+Cache County,Log11,U.S. House of Representatives,1,REP,Rob Bishop,241
+Cache County,Log12,U.S. House of Representatives,1,CON,Sherry Phipps,15
+Cache County,Log12,U.S. House of Representatives,1,DEM,Donna McAleer,91
+Cache County,Log12,U.S. House of Representatives,1,REP,Rob Bishop,221
+Cache County,Log13,U.S. House of Representatives,1,CON,Sherry Phipps,25
+Cache County,Log13,U.S. House of Representatives,1,DEM,Donna McAleer,250
+Cache County,Log13,U.S. House of Representatives,1,REP,Rob Bishop,411
+Cache County,Log14,U.S. House of Representatives,1,CON,Sherry Phipps,24
+Cache County,Log14,U.S. House of Representatives,1,DEM,Donna McAleer,171
+Cache County,Log14,U.S. House of Representatives,1,REP,Rob Bishop,252
+Cache County,Log15,U.S. House of Representatives,1,CON,Sherry Phipps,29
+Cache County,Log15,U.S. House of Representatives,1,DEM,Donna McAleer,77
+Cache County,Log15,U.S. House of Representatives,1,REP,Rob Bishop,321
+Cache County,Log16,U.S. House of Representatives,1,CON,Sherry Phipps,20
+Cache County,Log16,U.S. House of Representatives,1,DEM,Donna McAleer,127
+Cache County,Log16,U.S. House of Representatives,1,REP,Rob Bishop,291
+Cache County,Log17,U.S. House of Representatives,1,CON,Sherry Phipps,20
+Cache County,Log17,U.S. House of Representatives,1,DEM,Donna McAleer,114
+Cache County,Log17,U.S. House of Representatives,1,REP,Rob Bishop,381
+Cache County,Log18,U.S. House of Representatives,1,CON,Sherry Phipps,15
+Cache County,Log18,U.S. House of Representatives,1,DEM,Donna McAleer,38
+Cache County,Log18,U.S. House of Representatives,1,REP,Rob Bishop,360
+Cache County,Log19,U.S. House of Representatives,1,CON,Sherry Phipps,25
+Cache County,Log19,U.S. House of Representatives,1,DEM,Donna McAleer,54
+Cache County,Log19,U.S. House of Representatives,1,REP,Rob Bishop,258
+Cache County,Log20,U.S. House of Representatives,1,CON,Sherry Phipps,16
+Cache County,Log20,U.S. House of Representatives,1,DEM,Donna McAleer,165
+Cache County,Log20,U.S. House of Representatives,1,REP,Rob Bishop,468
+Cache County,Log21,U.S. House of Representatives,1,CON,Sherry Phipps,10
+Cache County,Log21,U.S. House of Representatives,1,DEM,Donna McAleer,170
+Cache County,Log21,U.S. House of Representatives,1,REP,Rob Bishop,230
+Cache County,Log22,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Log22,U.S. House of Representatives,1,DEM,Donna McAleer,208
+Cache County,Log22,U.S. House of Representatives,1,REP,Rob Bishop,498
+Cache County,Log23,U.S. House of Representatives,1,CON,Sherry Phipps,18
+Cache County,Log23,U.S. House of Representatives,1,DEM,Donna McAleer,64
+Cache County,Log23,U.S. House of Representatives,1,REP,Rob Bishop,337
+Cache County,Log24,U.S. House of Representatives,1,CON,Sherry Phipps,8
+Cache County,Log24,U.S. House of Representatives,1,DEM,Donna McAleer,90
+Cache County,Log24,U.S. House of Representatives,1,REP,Rob Bishop,160
+Cache County,Log25,U.S. House of Representatives,1,CON,Sherry Phipps,26
+Cache County,Log25,U.S. House of Representatives,1,DEM,Donna McAleer,102
+Cache County,Log25,U.S. House of Representatives,1,REP,Rob Bishop,358
+Cache County,Log26,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Log26,U.S. House of Representatives,1,DEM,Donna McAleer,94
+Cache County,Log26,U.S. House of Representatives,1,REP,Rob Bishop,369
+Cache County,Log27,U.S. House of Representatives,1,CON,Sherry Phipps,21
+Cache County,Log27,U.S. House of Representatives,1,DEM,Donna McAleer,89
+Cache County,Log27,U.S. House of Representatives,1,REP,Rob Bishop,382
+Cache County,Log28,U.S. House of Representatives,1,CON,Sherry Phipps,9
+Cache County,Log28,U.S. House of Representatives,1,DEM,Donna McAleer,42
+Cache County,Log28,U.S. House of Representatives,1,REP,Rob Bishop,153
+Cache County,Log29,U.S. House of Representatives,1,CON,Sherry Phipps,10
+Cache County,Log29,U.S. House of Representatives,1,DEM,Donna McAleer,197
+Cache County,Log29,U.S. House of Representatives,1,REP,Rob Bishop,490
+Cache County,Log30,U.S. House of Representatives,1,CON,Sherry Phipps,29
+Cache County,Log30,U.S. House of Representatives,1,DEM,Donna McAleer,92
+Cache County,Log30,U.S. House of Representatives,1,REP,Rob Bishop,367
+Cache County,Log31,U.S. House of Representatives,1,CON,Sherry Phipps,33
+Cache County,Log31,U.S. House of Representatives,1,DEM,Donna McAleer,96
+Cache County,Log31,U.S. House of Representatives,1,REP,Rob Bishop,385
+Cache County,Log32,U.S. House of Representatives,1,CON,Sherry Phipps,10
+Cache County,Log32,U.S. House of Representatives,1,DEM,Donna McAleer,73
+Cache County,Log32,U.S. House of Representatives,1,REP,Rob Bishop,228
+Cache County,Log33,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Log33,U.S. House of Representatives,1,DEM,Donna McAleer,100
+Cache County,Log33,U.S. House of Representatives,1,REP,Rob Bishop,287
+Cache County,Log33.5,U.S. House of Representatives,1,CON,Sherry Phipps,4
+Cache County,Log33.5,U.S. House of Representatives,1,DEM,Donna McAleer,28
+Cache County,Log33.5,U.S. House of Representatives,1,REP,Rob Bishop,89
+Cache County,Ama,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Ama,U.S. House of Representatives,1,DEM,Donna McAleer,21
+Cache County,Ama,U.S. House of Representatives,1,REP,Rob Bishop,168
+Cache County,Ben,U.S. House of Representatives,1,CON,Sherry Phipps,11
+Cache County,Ben,U.S. House of Representatives,1,DEM,Donna McAleer,58
+Cache County,Ben,U.S. House of Representatives,1,REP,Rob Bishop,243
+Cache County,Clk,U.S. House of Representatives,1,CON,Sherry Phipps,12
+Cache County,Clk,U.S. House of Representatives,1,DEM,Donna McAleer,29
+Cache County,Clk,U.S. House of Representatives,1,REP,Rob Bishop,277
+Cache County,C/Y,U.S. House of Representatives,1,CON,Sherry Phipps,20
+Cache County,C/Y,U.S. House of Representatives,1,DEM,Donna McAleer,51
+Cache County,C/Y,U.S. House of Representatives,1,REP,Rob Bishop,343
+Cache County,Cor,U.S. House of Representatives,1,CON,Sherry Phipps,2
+Cache County,Cor,U.S. House of Representatives,1,DEM,Donna McAleer,10
+Cache County,Cor,U.S. House of Representatives,1,REP,Rob Bishop,107
+Cache County,Cov,U.S. House of Representatives,1,CON,Sherry Phipps,14
+Cache County,Cov,U.S. House of Representatives,1,DEM,Donna McAleer,33
+Cache County,Cov,U.S. House of Representatives,1,REP,Rob Bishop,192
+Cache County,Hyd01,U.S. House of Representatives,1,CON,Sherry Phipps,32
+Cache County,Hyd01,U.S. House of Representatives,1,DEM,Donna McAleer,167
+Cache County,Hyd01,U.S. House of Representatives,1,REP,Rob Bishop,796
+Cache County,Hyd02,U.S. House of Representatives,1,CON,Sherry Phipps,32
+Cache County,Hyd02,U.S. House of Representatives,1,DEM,Donna McAleer,141
+Cache County,Hyd02,U.S. House of Representatives,1,REP,Rob Bishop,675
+Cache County,Hyr01,U.S. House of Representatives,1,CON,Sherry Phipps,35
+Cache County,Hyr01,U.S. House of Representatives,1,DEM,Donna McAleer,125
+Cache County,Hyr01,U.S. House of Representatives,1,REP,Rob Bishop,408
+Cache County,Hyr02,U.S. House of Representatives,1,CON,Sherry Phipps,16
+Cache County,Hyr02,U.S. House of Representatives,1,DEM,Donna McAleer,42
+Cache County,Hyr02,U.S. House of Representatives,1,REP,Rob Bishop,245
+Cache County,Hyr03,U.S. House of Representatives,1,CON,Sherry Phipps,22
+Cache County,Hyr03,U.S. House of Representatives,1,DEM,Donna McAleer,92
+Cache County,Hyr03,U.S. House of Representatives,1,REP,Rob Bishop,503
+Cache County,Hyr04,U.S. House of Representatives,1,CON,Sherry Phipps,44
+Cache County,Hyr04,U.S. House of Representatives,1,DEM,Donna McAleer,87
+Cache County,Hyr04,U.S. House of Representatives,1,REP,Rob Bishop,570
+Cache County,Hyr05,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Hyr05,U.S. House of Representatives,1,DEM,Donna McAleer,64
+Cache County,Hyr05,U.S. House of Representatives,1,REP,Rob Bishop,369
+Cache County,Lew01,U.S. House of Representatives,1,CON,Sherry Phipps,25
+Cache County,Lew01,U.S. House of Representatives,1,DEM,Donna McAleer,58
+Cache County,Lew01,U.S. House of Representatives,1,REP,Rob Bishop,388
+Cache County,Lew02,U.S. House of Representatives,1,CON,Sherry Phipps,9
+Cache County,Lew02,U.S. House of Representatives,1,DEM,Donna McAleer,21
+Cache County,Lew02,U.S. House of Representatives,1,REP,Rob Bishop,254
+Cache County,Men01,U.S. House of Representatives,1,CON,Sherry Phipps,4
+Cache County,Men01,U.S. House of Representatives,1,DEM,Donna McAleer,14
+Cache County,Men01,U.S. House of Representatives,1,REP,Rob Bishop,57
+Cache County,Men02,U.S. House of Representatives,1,CON,Sherry Phipps,39
+Cache County,Men02,U.S. House of Representatives,1,DEM,Donna McAleer,123
+Cache County,Men02,U.S. House of Representatives,1,REP,Rob Bishop,707
+Cache County,Mil17,U.S. House of Representatives,1,CON,Sherry Phipps,2
+Cache County,Mil17,U.S. House of Representatives,1,DEM,Donna McAleer,19
+Cache County,Mil17,U.S. House of Representatives,1,REP,Rob Bishop,81
+Cache County,Mil25,U.S. House of Representatives,1,CON,Sherry Phipps,34
+Cache County,Mil25,U.S. House of Representatives,1,DEM,Donna McAleer,93
+Cache County,Mil25,U.S. House of Representatives,1,REP,Rob Bishop,612
+Cache County,New,U.S. House of Representatives,1,CON,Sherry Phipps,12
+Cache County,New,U.S. House of Representatives,1,DEM,Donna McAleer,63
+Cache County,New,U.S. House of Representatives,1,REP,Rob Bishop,338
+Cache County,Nib01,U.S. House of Representatives,1,CON,Sherry Phipps,36
+Cache County,Nib01,U.S. House of Representatives,1,DEM,Donna McAleer,77
+Cache County,Nib01,U.S. House of Representatives,1,REP,Rob Bishop,533
+Cache County,Nib03,U.S. House of Representatives,1,CON,Sherry Phipps,35
+Cache County,Nib03,U.S. House of Representatives,1,DEM,Donna McAleer,128
+Cache County,Nib03,U.S. House of Representatives,1,REP,Rob Bishop,611
+Cache County,Nib17,U.S. House of Representatives,1,CON,Sherry Phipps,25
+Cache County,Nib17,U.S. House of Representatives,1,DEM,Donna McAleer,83
+Cache County,Nib17,U.S. House of Representatives,1,REP,Rob Bishop,471
+Cache County,Nib25,U.S. House of Representatives,1,CON,Sherry Phipps,0
+Cache County,Nib25,U.S. House of Representatives,1,DEM,Donna McAleer,0
+Cache County,Nib25,U.S. House of Representatives,1,REP,Rob Bishop,20
+Cache County,Nlg01,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Nlg01,U.S. House of Representatives,1,DEM,Donna McAleer,127
+Cache County,Nlg01,U.S. House of Representatives,1,REP,Rob Bishop,381
+Cache County,Nlg02,U.S. House of Representatives,1,CON,Sherry Phipps,15
+Cache County,Nlg02,U.S. House of Representatives,1,DEM,Donna McAleer,112
+Cache County,Nlg02,U.S. House of Representatives,1,REP,Rob Bishop,383
+Cache County,Nlg03,U.S. House of Representatives,1,CON,Sherry Phipps,16
+Cache County,Nlg03,U.S. House of Representatives,1,DEM,Donna McAleer,76
+Cache County,Nlg03,U.S. House of Representatives,1,REP,Rob Bishop,456
+Cache County,Nlg04,U.S. House of Representatives,1,CON,Sherry Phipps,20
+Cache County,Nlg04,U.S. House of Representatives,1,DEM,Donna McAleer,114
+Cache County,Nlg04,U.S. House of Representatives,1,REP,Rob Bishop,492
+Cache County,Nlg05,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Nlg05,U.S. House of Representatives,1,DEM,Donna McAleer,143
+Cache County,Nlg05,U.S. House of Representatives,1,REP,Rob Bishop,522
+Cache County,Nlg06,U.S. House of Representatives,1,CON,Sherry Phipps,27
+Cache County,Nlg06,U.S. House of Representatives,1,DEM,Donna McAleer,163
+Cache County,Nlg06,U.S. House of Representatives,1,REP,Rob Bishop,377
+Cache County,Par,U.S. House of Representatives,1,CON,Sherry Phipps,48
+Cache County,Par,U.S. House of Representatives,1,DEM,Donna McAleer,114
+Cache County,Par,U.S. House of Representatives,1,REP,Rob Bishop,600
+Cache County,Pro01,U.S. House of Representatives,1,CON,Sherry Phipps,30
+Cache County,Pro01,U.S. House of Representatives,1,DEM,Donna McAleer,104
+Cache County,Pro01,U.S. House of Representatives,1,REP,Rob Bishop,539
+Cache County,Pro02,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Pro02,U.S. House of Representatives,1,DEM,Donna McAleer,173
+Cache County,Pro02,U.S. House of Representatives,1,REP,Rob Bishop,705
+Cache County,Pro03,U.S. House of Representatives,1,CON,Sherry Phipps,11
+Cache County,Pro03,U.S. House of Representatives,1,DEM,Donna McAleer,89
+Cache County,Pro03,U.S. House of Representatives,1,REP,Rob Bishop,538
+Cache County,Pro04,U.S. House of Representatives,1,CON,Sherry Phipps,24
+Cache County,Pro04,U.S. House of Representatives,1,DEM,Donna McAleer,105
+Cache County,Pro04,U.S. House of Representatives,1,REP,Rob Bishop,467
+Cache County,Pro05,U.S. House of Representatives,1,CON,Sherry Phipps,12
+Cache County,Pro05,U.S. House of Representatives,1,DEM,Donna McAleer,75
+Cache County,Pro05,U.S. House of Representatives,1,REP,Rob Bishop,377
+Cache County,Rch01,U.S. House of Representatives,1,CON,Sherry Phipps,18
+Cache County,Rch01,U.S. House of Representatives,1,DEM,Donna McAleer,89
+Cache County,Rch01,U.S. House of Representatives,1,REP,Rob Bishop,394
+Cache County,Rch02,U.S. House of Representatives,1,CON,Sherry Phipps,31
+Cache County,Rch02,U.S. House of Representatives,1,DEM,Donna McAleer,70
+Cache County,Rch02,U.S. House of Representatives,1,REP,Rob Bishop,432
+Cache County,Rvh01,U.S. House of Representatives,1,CON,Sherry Phipps,13
+Cache County,Rvh01,U.S. House of Representatives,1,DEM,Donna McAleer,90
+Cache County,Rvh01,U.S. House of Representatives,1,REP,Rob Bishop,262
+Cache County,Rvh02,U.S. House of Representatives,1,CON,Sherry Phipps,21
+Cache County,Rvh02,U.S. House of Representatives,1,DEM,Donna McAleer,102
+Cache County,Rvh02,U.S. House of Representatives,1,REP,Rob Bishop,365
+Cache County,Smi01,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Smi01,U.S. House of Representatives,1,DEM,Donna McAleer,58
+Cache County,Smi01,U.S. House of Representatives,1,REP,Rob Bishop,467
+Cache County,Smi02,U.S. House of Representatives,1,CON,Sherry Phipps,24
+Cache County,Smi02,U.S. House of Representatives,1,DEM,Donna McAleer,120
+Cache County,Smi02,U.S. House of Representatives,1,REP,Rob Bishop,496
+Cache County,Smi03,U.S. House of Representatives,1,CON,Sherry Phipps,15
+Cache County,Smi03,U.S. House of Representatives,1,DEM,Donna McAleer,107
+Cache County,Smi03,U.S. House of Representatives,1,REP,Rob Bishop,519
+Cache County,Smi04,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Smi04,U.S. House of Representatives,1,DEM,Donna McAleer,87
+Cache County,Smi04,U.S. House of Representatives,1,REP,Rob Bishop,513
+Cache County,Smi05,U.S. House of Representatives,1,CON,Sherry Phipps,26
+Cache County,Smi05,U.S. House of Representatives,1,DEM,Donna McAleer,57
+Cache County,Smi05,U.S. House of Representatives,1,REP,Rob Bishop,375
+Cache County,Smi06,U.S. House of Representatives,1,CON,Sherry Phipps,32
+Cache County,Smi06,U.S. House of Representatives,1,DEM,Donna McAleer,78
+Cache County,Smi06,U.S. House of Representatives,1,REP,Rob Bishop,471
+Cache County,Smi07,U.S. House of Representatives,1,CON,Sherry Phipps,23
+Cache County,Smi07,U.S. House of Representatives,1,DEM,Donna McAleer,115
+Cache County,Smi07,U.S. House of Representatives,1,REP,Rob Bishop,565
+Cache County,Tre,U.S. House of Representatives,1,CON,Sherry Phipps,11
+Cache County,Tre,U.S. House of Representatives,1,DEM,Donna McAleer,30
+Cache County,Tre,U.S. House of Representatives,1,REP,Rob Bishop,174
+Cache County,Wel01,U.S. House of Representatives,1,CON,Sherry Phipps,13
+Cache County,Wel01,U.S. House of Representatives,1,DEM,Donna McAleer,42
+Cache County,Wel01,U.S. House of Representatives,1,REP,Rob Bishop,326
+Cache County,Wel02,U.S. House of Representatives,1,CON,Sherry Phipps,21
+Cache County,Wel02,U.S. House of Representatives,1,DEM,Donna McAleer,69
+Cache County,Wel02,U.S. House of Representatives,1,REP,Rob Bishop,427
+Cache County,Wel03,U.S. House of Representatives,1,CON,Sherry Phipps,12
+Cache County,Wel03,U.S. House of Representatives,1,DEM,Donna McAleer,55
+Cache County,Wel03,U.S. House of Representatives,1,REP,Rob Bishop,288
+Cache County,Wel04,U.S. House of Representatives,1,CON,Sherry Phipps,19
+Cache County,Wel04,U.S. House of Representatives,1,DEM,Donna McAleer,73
+Cache County,Wel04,U.S. House of Representatives,1,REP,Rob Bishop,419
+Cache County,Log01,Attorney General,,DEM,Dee W. Smith,99
+Cache County,Log01,Attorney General,,REP,John Swallow,194
+Cache County,Log01,Attorney General,,LIB,Andrew W. McCullough,34
+Cache County,Log02,Attorney General,,DEM,Dee W. Smith,124
+Cache County,Log02,Attorney General,,REP,John Swallow,275
+Cache County,Log02,Attorney General,,LIB,Andrew W. McCullough,53
+Cache County,Log03,Attorney General,,DEM,Dee W. Smith,122
+Cache County,Log03,Attorney General,,REP,John Swallow,367
+Cache County,Log03,Attorney General,,LIB,Andrew W. McCullough,44
+Cache County,Log04,Attorney General,,DEM,Dee W. Smith,110
+Cache County,Log04,Attorney General,,REP,John Swallow,290
+Cache County,Log04,Attorney General,,LIB,Andrew W. McCullough,43
+Cache County,Log05,Attorney General,,DEM,Dee W. Smith,203
+Cache County,Log05,Attorney General,,REP,John Swallow,379
+Cache County,Log05,Attorney General,,LIB,Andrew W. McCullough,48
+Cache County,Log06,Attorney General,,DEM,Dee W. Smith,119
+Cache County,Log06,Attorney General,,REP,John Swallow,297
+Cache County,Log06,Attorney General,,LIB,Andrew W. McCullough,35
+Cache County,Log07,Attorney General,,DEM,Dee W. Smith,89
+Cache County,Log07,Attorney General,,REP,John Swallow,149
+Cache County,Log07,Attorney General,,LIB,Andrew W. McCullough,21
+Cache County,Log08,Attorney General,,DEM,Dee W. Smith,64
+Cache County,Log08,Attorney General,,REP,John Swallow,138
+Cache County,Log08,Attorney General,,LIB,Andrew W. McCullough,18
+Cache County,Log09,Attorney General,,DEM,Dee W. Smith,128
+Cache County,Log09,Attorney General,,REP,John Swallow,218
+Cache County,Log09,Attorney General,,LIB,Andrew W. McCullough,26
+Cache County,Log10,Attorney General,,DEM,Dee W. Smith,81
+Cache County,Log10,Attorney General,,REP,John Swallow,192
+Cache County,Log10,Attorney General,,LIB,Andrew W. McCullough,26
+Cache County,Log11,Attorney General,,DEM,Dee W. Smith,60
+Cache County,Log11,Attorney General,,REP,John Swallow,230
+Cache County,Log11,Attorney General,,LIB,Andrew W. McCullough,31
+Cache County,Log12,Attorney General,,DEM,Dee W. Smith,80
+Cache County,Log12,Attorney General,,REP,John Swallow,202
+Cache County,Log12,Attorney General,,LIB,Andrew W. McCullough,35
+Cache County,Log13,Attorney General,,DEM,Dee W. Smith,231
+Cache County,Log13,Attorney General,,REP,John Swallow,399
+Cache County,Log13,Attorney General,,LIB,Andrew W. McCullough,43
+Cache County,Log14,Attorney General,,DEM,Dee W. Smith,166
+Cache County,Log14,Attorney General,,REP,John Swallow,245
+Cache County,Log14,Attorney General,,LIB,Andrew W. McCullough,30
+Cache County,Log15,Attorney General,,DEM,Dee W. Smith,74
+Cache County,Log15,Attorney General,,REP,John Swallow,299
+Cache County,Log15,Attorney General,,LIB,Andrew W. McCullough,41
+Cache County,Log16,Attorney General,,DEM,Dee W. Smith,132
+Cache County,Log16,Attorney General,,REP,John Swallow,261
+Cache County,Log16,Attorney General,,LIB,Andrew W. McCullough,33
+Cache County,Log17,Attorney General,,DEM,Dee W. Smith,98
+Cache County,Log17,Attorney General,,REP,John Swallow,365
+Cache County,Log17,Attorney General,,LIB,Andrew W. McCullough,42
+Cache County,Log18,Attorney General,,DEM,Dee W. Smith,46
+Cache County,Log18,Attorney General,,REP,John Swallow,318
+Cache County,Log18,Attorney General,,LIB,Andrew W. McCullough,30
+Cache County,Log19,Attorney General,,DEM,Dee W. Smith,62
+Cache County,Log19,Attorney General,,REP,John Swallow,252
+Cache County,Log19,Attorney General,,LIB,Andrew W. McCullough,24
+Cache County,Log20,Attorney General,,DEM,Dee W. Smith,178
+Cache County,Log20,Attorney General,,REP,John Swallow,429
+Cache County,Log20,Attorney General,,LIB,Andrew W. McCullough,35
+Cache County,Log21,Attorney General,,DEM,Dee W. Smith,161
+Cache County,Log21,Attorney General,,REP,John Swallow,231
+Cache County,Log21,Attorney General,,LIB,Andrew W. McCullough,10
+Cache County,Log22,Attorney General,,DEM,Dee W. Smith,189
+Cache County,Log22,Attorney General,,REP,John Swallow,487
+Cache County,Log22,Attorney General,,LIB,Andrew W. McCullough,38
+Cache County,Log23,Attorney General,,DEM,Dee W. Smith,57
+Cache County,Log23,Attorney General,,REP,John Swallow,302
+Cache County,Log23,Attorney General,,LIB,Andrew W. McCullough,37
+Cache County,Log24,Attorney General,,DEM,Dee W. Smith,85
+Cache County,Log24,Attorney General,,REP,John Swallow,151
+Cache County,Log24,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Log25,Attorney General,,DEM,Dee W. Smith,101
+Cache County,Log25,Attorney General,,REP,John Swallow,336
+Cache County,Log25,Attorney General,,LIB,Andrew W. McCullough,36
+Cache County,Log26,Attorney General,,DEM,Dee W. Smith,92
+Cache County,Log26,Attorney General,,REP,John Swallow,358
+Cache County,Log26,Attorney General,,LIB,Andrew W. McCullough,27
+Cache County,Log27,Attorney General,,DEM,Dee W. Smith,81
+Cache County,Log27,Attorney General,,REP,John Swallow,374
+Cache County,Log27,Attorney General,,LIB,Andrew W. McCullough,29
+Cache County,Log28,Attorney General,,DEM,Dee W. Smith,41
+Cache County,Log28,Attorney General,,REP,John Swallow,149
+Cache County,Log28,Attorney General,,LIB,Andrew W. McCullough,10
+Cache County,Log29,Attorney General,,DEM,Dee W. Smith,188
+Cache County,Log29,Attorney General,,REP,John Swallow,464
+Cache County,Log29,Attorney General,,LIB,Andrew W. McCullough,29
+Cache County,Log30,Attorney General,,DEM,Dee W. Smith,96
+Cache County,Log30,Attorney General,,REP,John Swallow,350
+Cache County,Log30,Attorney General,,LIB,Andrew W. McCullough,32
+Cache County,Log31,Attorney General,,DEM,Dee W. Smith,103
+Cache County,Log31,Attorney General,,REP,John Swallow,350
+Cache County,Log31,Attorney General,,LIB,Andrew W. McCullough,45
+Cache County,Log32,Attorney General,,DEM,Dee W. Smith,71
+Cache County,Log32,Attorney General,,REP,John Swallow,215
+Cache County,Log32,Attorney General,,LIB,Andrew W. McCullough,20
+Cache County,Log33,Attorney General,,DEM,Dee W. Smith,98
+Cache County,Log33,Attorney General,,REP,John Swallow,279
+Cache County,Log33,Attorney General,,LIB,Andrew W. McCullough,28
+Cache County,Log33.5,Attorney General,,DEM,Dee W. Smith,27
+Cache County,Log33.5,Attorney General,,REP,John Swallow,82
+Cache County,Log33.5,Attorney General,,LIB,Andrew W. McCullough,7
+Cache County,Ama,Attorney General,,DEM,Dee W. Smith,34
+Cache County,Ama,Attorney General,,REP,John Swallow,164
+Cache County,Ama,Attorney General,,LIB,Andrew W. McCullough,8
+Cache County,Ben,Attorney General,,DEM,Dee W. Smith,48
+Cache County,Ben,Attorney General,,REP,John Swallow,247
+Cache County,Ben,Attorney General,,LIB,Andrew W. McCullough,14
+Cache County,Clk,Attorney General,,DEM,Dee W. Smith,43
+Cache County,Clk,Attorney General,,REP,John Swallow,268
+Cache County,Clk,Attorney General,,LIB,Andrew W. McCullough,8
+Cache County,C/Y,Attorney General,,DEM,Dee W. Smith,51
+Cache County,C/Y,Attorney General,,REP,John Swallow,323
+Cache County,C/Y,Attorney General,,LIB,Andrew W. McCullough,29
+Cache County,Cor,Attorney General,,DEM,Dee W. Smith,14
+Cache County,Cor,Attorney General,,REP,John Swallow,100
+Cache County,Cor,Attorney General,,LIB,Andrew W. McCullough,5
+Cache County,Cov,Attorney General,,DEM,Dee W. Smith,34
+Cache County,Cov,Attorney General,,REP,John Swallow,188
+Cache County,Cov,Attorney General,,LIB,Andrew W. McCullough,11
+Cache County,Hyd01,Attorney General,,DEM,Dee W. Smith,170
+Cache County,Hyd01,Attorney General,,REP,John Swallow,747
+Cache County,Hyd01,Attorney General,,LIB,Andrew W. McCullough,47
+Cache County,Hyd02,Attorney General,,DEM,Dee W. Smith,139
+Cache County,Hyd02,Attorney General,,REP,John Swallow,653
+Cache County,Hyd02,Attorney General,,LIB,Andrew W. McCullough,36
+Cache County,Hyr01,Attorney General,,DEM,Dee W. Smith,104
+Cache County,Hyr01,Attorney General,,REP,John Swallow,424
+Cache County,Hyr01,Attorney General,,LIB,Andrew W. McCullough,35
+Cache County,Hyr02,Attorney General,,DEM,Dee W. Smith,50
+Cache County,Hyr02,Attorney General,,REP,John Swallow,229
+Cache County,Hyr02,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Hyr03,Attorney General,,DEM,Dee W. Smith,91
+Cache County,Hyr03,Attorney General,,REP,John Swallow,491
+Cache County,Hyr03,Attorney General,,LIB,Andrew W. McCullough,30
+Cache County,Hyr04,Attorney General,,DEM,Dee W. Smith,83
+Cache County,Hyr04,Attorney General,,REP,John Swallow,574
+Cache County,Hyr04,Attorney General,,LIB,Andrew W. McCullough,49
+Cache County,Hyr05,Attorney General,,DEM,Dee W. Smith,60
+Cache County,Hyr05,Attorney General,,REP,John Swallow,357
+Cache County,Hyr05,Attorney General,,LIB,Andrew W. McCullough,32
+Cache County,Lew01,Attorney General,,DEM,Dee W. Smith,55
+Cache County,Lew01,Attorney General,,REP,John Swallow,382
+Cache County,Lew01,Attorney General,,LIB,Andrew W. McCullough,27
+Cache County,Lew02,Attorney General,,DEM,Dee W. Smith,27
+Cache County,Lew02,Attorney General,,REP,John Swallow,243
+Cache County,Lew02,Attorney General,,LIB,Andrew W. McCullough,13
+Cache County,Men01,Attorney General,,DEM,Dee W. Smith,12
+Cache County,Men01,Attorney General,,REP,John Swallow,53
+Cache County,Men01,Attorney General,,LIB,Andrew W. McCullough,7
+Cache County,Men02,Attorney General,,DEM,Dee W. Smith,122
+Cache County,Men02,Attorney General,,REP,John Swallow,688
+Cache County,Men02,Attorney General,,LIB,Andrew W. McCullough,48
+Cache County,Mil17,Attorney General,,DEM,Dee W. Smith,18
+Cache County,Mil17,Attorney General,,REP,John Swallow,78
+Cache County,Mil17,Attorney General,,LIB,Andrew W. McCullough,7
+Cache County,Mil25,Attorney General,,DEM,Dee W. Smith,94
+Cache County,Mil25,Attorney General,,REP,John Swallow,594
+Cache County,Mil25,Attorney General,,LIB,Andrew W. McCullough,31
+Cache County,New,Attorney General,,DEM,Dee W. Smith,62
+Cache County,New,Attorney General,,REP,John Swallow,328
+Cache County,New,Attorney General,,LIB,Andrew W. McCullough,22
+Cache County,Nib01,Attorney General,,DEM,Dee W. Smith,85
+Cache County,Nib01,Attorney General,,REP,John Swallow,500
+Cache County,Nib01,Attorney General,,LIB,Andrew W. McCullough,37
+Cache County,Nib03,Attorney General,,DEM,Dee W. Smith,130
+Cache County,Nib03,Attorney General,,REP,John Swallow,601
+Cache County,Nib03,Attorney General,,LIB,Andrew W. McCullough,33
+Cache County,Nib17,Attorney General,,DEM,Dee W. Smith,73
+Cache County,Nib17,Attorney General,,REP,John Swallow,470
+Cache County,Nib17,Attorney General,,LIB,Andrew W. McCullough,26
+Cache County,Nib25,Attorney General,,DEM,Dee W. Smith,1
+Cache County,Nib25,Attorney General,,REP,John Swallow,19
+Cache County,Nib25,Attorney General,,LIB,Andrew W. McCullough,0
+Cache County,Nlg01,Attorney General,,DEM,Dee W. Smith,123
+Cache County,Nlg01,Attorney General,,REP,John Swallow,355
+Cache County,Nlg01,Attorney General,,LIB,Andrew W. McCullough,39
+Cache County,Nlg02,Attorney General,,DEM,Dee W. Smith,103
+Cache County,Nlg02,Attorney General,,REP,John Swallow,354
+Cache County,Nlg02,Attorney General,,LIB,Andrew W. McCullough,39
+Cache County,Nlg03,Attorney General,,DEM,Dee W. Smith,82
+Cache County,Nlg03,Attorney General,,REP,John Swallow,439
+Cache County,Nlg03,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Nlg04,Attorney General,,DEM,Dee W. Smith,113
+Cache County,Nlg04,Attorney General,,REP,John Swallow,473
+Cache County,Nlg04,Attorney General,,LIB,Andrew W. McCullough,22
+Cache County,Nlg05,Attorney General,,DEM,Dee W. Smith,130
+Cache County,Nlg05,Attorney General,,REP,John Swallow,511
+Cache County,Nlg05,Attorney General,,LIB,Andrew W. McCullough,37
+Cache County,Nlg06,Attorney General,,DEM,Dee W. Smith,167
+Cache County,Nlg06,Attorney General,,REP,John Swallow,370
+Cache County,Nlg06,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Par,Attorney General,,DEM,Dee W. Smith,105
+Cache County,Par,Attorney General,,REP,John Swallow,605
+Cache County,Par,Attorney General,,LIB,Andrew W. McCullough,36
+Cache County,Pro01,Attorney General,,DEM,Dee W. Smith,96
+Cache County,Pro01,Attorney General,,REP,John Swallow,531
+Cache County,Pro01,Attorney General,,LIB,Andrew W. McCullough,40
+Cache County,Pro02,Attorney General,,DEM,Dee W. Smith,155
+Cache County,Pro02,Attorney General,,REP,John Swallow,698
+Cache County,Pro02,Attorney General,,LIB,Andrew W. McCullough,32
+Cache County,Pro03,Attorney General,,DEM,Dee W. Smith,90
+Cache County,Pro03,Attorney General,,REP,John Swallow,510
+Cache County,Pro03,Attorney General,,LIB,Andrew W. McCullough,24
+Cache County,Pro04,Attorney General,,DEM,Dee W. Smith,105
+Cache County,Pro04,Attorney General,,REP,John Swallow,451
+Cache County,Pro04,Attorney General,,LIB,Andrew W. McCullough,26
+Cache County,Pro05,Attorney General,,DEM,Dee W. Smith,73
+Cache County,Pro05,Attorney General,,REP,John Swallow,362
+Cache County,Pro05,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Rch01,Attorney General,,DEM,Dee W. Smith,79
+Cache County,Rch01,Attorney General,,REP,John Swallow,390
+Cache County,Rch01,Attorney General,,LIB,Andrew W. McCullough,28
+Cache County,Rch02,Attorney General,,DEM,Dee W. Smith,92
+Cache County,Rch02,Attorney General,,REP,John Swallow,408
+Cache County,Rch02,Attorney General,,LIB,Andrew W. McCullough,24
+Cache County,Rvh01,Attorney General,,DEM,Dee W. Smith,77
+Cache County,Rvh01,Attorney General,,REP,John Swallow,262
+Cache County,Rvh01,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Rvh02,Attorney General,,DEM,Dee W. Smith,96
+Cache County,Rvh02,Attorney General,,REP,John Swallow,358
+Cache County,Rvh02,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Smi01,Attorney General,,DEM,Dee W. Smith,72
+Cache County,Smi01,Attorney General,,REP,John Swallow,433
+Cache County,Smi01,Attorney General,,LIB,Andrew W. McCullough,30
+Cache County,Smi02,Attorney General,,DEM,Dee W. Smith,117
+Cache County,Smi02,Attorney General,,REP,John Swallow,477
+Cache County,Smi02,Attorney General,,LIB,Andrew W. McCullough,34
+Cache County,Smi03,Attorney General,,DEM,Dee W. Smith,108
+Cache County,Smi03,Attorney General,,REP,John Swallow,499
+Cache County,Smi03,Attorney General,,LIB,Andrew W. McCullough,32
+Cache County,Smi04,Attorney General,,DEM,Dee W. Smith,90
+Cache County,Smi04,Attorney General,,REP,John Swallow,488
+Cache County,Smi04,Attorney General,,LIB,Andrew W. McCullough,26
+Cache County,Smi05,Attorney General,,DEM,Dee W. Smith,73
+Cache County,Smi05,Attorney General,,REP,John Swallow,341
+Cache County,Smi05,Attorney General,,LIB,Andrew W. McCullough,35
+Cache County,Smi06,Attorney General,,DEM,Dee W. Smith,74
+Cache County,Smi06,Attorney General,,REP,John Swallow,457
+Cache County,Smi06,Attorney General,,LIB,Andrew W. McCullough,40
+Cache County,Smi07,Attorney General,,DEM,Dee W. Smith,113
+Cache County,Smi07,Attorney General,,REP,John Swallow,541
+Cache County,Smi07,Attorney General,,LIB,Andrew W. McCullough,30
+Cache County,Tre,Attorney General,,DEM,Dee W. Smith,34
+Cache County,Tre,Attorney General,,REP,John Swallow,170
+Cache County,Tre,Attorney General,,LIB,Andrew W. McCullough,11
+Cache County,Wel01,Attorney General,,DEM,Dee W. Smith,34
+Cache County,Wel01,Attorney General,,REP,John Swallow,311
+Cache County,Wel01,Attorney General,,LIB,Andrew W. McCullough,23
+Cache County,Wel02,Attorney General,,DEM,Dee W. Smith,65
+Cache County,Wel02,Attorney General,,REP,John Swallow,412
+Cache County,Wel02,Attorney General,,LIB,Andrew W. McCullough,31
+Cache County,Wel03,Attorney General,,DEM,Dee W. Smith,55
+Cache County,Wel03,Attorney General,,REP,John Swallow,276
+Cache County,Wel03,Attorney General,,LIB,Andrew W. McCullough,14
+Cache County,Wel04,Attorney General,,DEM,Dee W. Smith,78
+Cache County,Wel04,Attorney General,,REP,John Swallow,412
+Cache County,Wel04,Attorney General,,LIB,Andrew W. McCullough,20
+Cache County,Log01,State Senate,25,REP,Lyle Hillyard,274
+Cache County,Log02,State Senate,25,REP,Lyle Hillyard,369
+Cache County,Log03,State Senate,25,REP,Lyle Hillyard,479
+Cache County,Log04,State Senate,25,REP,Lyle Hillyard,360
+Cache County,Log05,State Senate,25,REP,Lyle Hillyard,498
+Cache County,Log06,State Senate,25,REP,Lyle Hillyard,367
+Cache County,Log07,State Senate,25,REP,Lyle Hillyard,204
+Cache County,Log08,State Senate,25,REP,Lyle Hillyard,179
+Cache County,Log09,State Senate,25,REP,Lyle Hillyard,285
+Cache County,Log10,State Senate,25,REP,Lyle Hillyard,240
+Cache County,Log11,State Senate,25,REP,Lyle Hillyard,272
+Cache County,Log12,State Senate,25,REP,Lyle Hillyard,272
+Cache County,Log13,State Senate,25,REP,Lyle Hillyard,542
+Cache County,Log14,State Senate,25,REP,Lyle Hillyard,336
+Cache County,Log15,State Senate,25,REP,Lyle Hillyard,364
+Cache County,Log16,State Senate,25,REP,Lyle Hillyard,346
+Cache County,Log17,State Senate,25,REP,Lyle Hillyard,446
+Cache County,Log18,State Senate,25,REP,Lyle Hillyard,374
+Cache County,Log19,State Senate,25,REP,Lyle Hillyard,295
+Cache County,Log20,State Senate,25,REP,Lyle Hillyard,571
+Cache County,Log21,State Senate,25,REP,Lyle Hillyard,326
+Cache County,Log22,State Senate,25,REP,Lyle Hillyard,587
+Cache County,Log23,State Senate,25,REP,Lyle Hillyard,368
+Cache County,Log24,State Senate,25,REP,Lyle Hillyard,192
+Cache County,Log25,State Senate,25,REP,Lyle Hillyard,436
+Cache County,Log26,State Senate,25,REP,Lyle Hillyard,407
+Cache County,Log27,State Senate,25,REP,Lyle Hillyard,413
+Cache County,Log28,State Senate,25,REP,Lyle Hillyard,180
+Cache County,Log29,State Senate,25,REP,Lyle Hillyard,565
+Cache County,Log30,State Senate,25,REP,Lyle Hillyard,420
+Cache County,Log31,State Senate,25,REP,Lyle Hillyard,438
+Cache County,Log32,State Senate,25,REP,Lyle Hillyard,271
+Cache County,Log33,State Senate,25,REP,Lyle Hillyard,350
+Cache County,Log33.5,State Senate,25,REP,Lyle Hillyard,103
+Cache County,Ama,State Senate,25,REP,Lyle Hillyard,188
+Cache County,Ben,State Senate,25,REP,Lyle Hillyard,267
+Cache County,Clk,State Senate,25,REP,Lyle Hillyard,291
+Cache County,C/Y,State Senate,25,REP,Lyle Hillyard,371
+Cache County,Cor,State Senate,25,REP,Lyle Hillyard,109
+Cache County,Cov,State Senate,25,REP,Lyle Hillyard,212
+Cache County,Hyd01,State Senate,25,REP,Lyle Hillyard,865
+Cache County,Hyd02,State Senate,25,REP,Lyle Hillyard,741
+Cache County,Hyr01,State Senate,25,REP,Lyle Hillyard,
+Cache County,Hyr02,State Senate,25,REP,Lyle Hillyard,
+Cache County,Hyr03,State Senate,25,REP,Lyle Hillyard,
+Cache County,Hyr04,State Senate,25,REP,Lyle Hillyard,
+Cache County,Hyr05,State Senate,25,REP,Lyle Hillyard,
+Cache County,Lew01,State Senate,25,REP,Lyle Hillyard,430
+Cache County,Lew02,State Senate,25,REP,Lyle Hillyard,268
+Cache County,Men01,State Senate,25,REP,Lyle Hillyard,62
+Cache County,Men02,State Senate,25,REP,Lyle Hillyard,777
+Cache County,Mil17,State Senate,25,REP,Lyle Hillyard,
+Cache County,Mil25,State Senate,25,REP,Lyle Hillyard,666
+Cache County,New,State Senate,25,REP,Lyle Hillyard,369
+Cache County,Nib01,State Senate,25,REP,Lyle Hillyard,
+Cache County,Nib03,State Senate,25,REP,Lyle Hillyard,
+Cache County,Nib17,State Senate,25,REP,Lyle Hillyard,
+Cache County,Nib25,State Senate,25,REP,Lyle Hillyard,19
+Cache County,Nlg01,State Senate,25,REP,Lyle Hillyard,439
+Cache County,Nlg02,State Senate,25,REP,Lyle Hillyard,431
+Cache County,Nlg03,State Senate,25,REP,Lyle Hillyard,499
+Cache County,Nlg04,State Senate,25,REP,Lyle Hillyard,543
+Cache County,Nlg05,State Senate,25,REP,Lyle Hillyard,607
+Cache County,Nlg06,State Senate,25,REP,Lyle Hillyard,464
+Cache County,Par,State Senate,25,REP,Lyle Hillyard,
+Cache County,Pro01,State Senate,25,REP,Lyle Hillyard,603
+Cache County,Pro02,State Senate,25,REP,Lyle Hillyard,798
+Cache County,Pro03,State Senate,25,REP,Lyle Hillyard,569
+Cache County,Pro04,State Senate,25,REP,Lyle Hillyard,510
+Cache County,Pro05,State Senate,25,REP,Lyle Hillyard,416
+Cache County,Rch01,State Senate,25,REP,Lyle Hillyard,444
+Cache County,Rch02,State Senate,25,REP,Lyle Hillyard,486
+Cache County,Rvh01,State Senate,25,REP,Lyle Hillyard,298
+Cache County,Rvh02,State Senate,25,REP,Lyle Hillyard,420
+Cache County,Smi01,State Senate,25,REP,Lyle Hillyard,516
+Cache County,Smi02,State Senate,25,REP,Lyle Hillyard,557
+Cache County,Smi03,State Senate,25,REP,Lyle Hillyard,578
+Cache County,Smi04,State Senate,25,REP,Lyle Hillyard,547
+Cache County,Smi05,State Senate,25,REP,Lyle Hillyard,426
+Cache County,Smi06,State Senate,25,REP,Lyle Hillyard,535
+Cache County,Smi07,State Senate,25,REP,Lyle Hillyard,625
+Cache County,Tre,State Senate,25,REP,Lyle Hillyard,209
+Cache County,Wel01,State Senate,25,REP,Lyle Hillyard,
+Cache County,Wel02,State Senate,25,REP,Lyle Hillyard,
+Cache County,Wel03,State Senate,25,REP,Lyle Hillyard,
+Cache County,Wel04,State Senate,25,REP,Lyle Hillyard,
+Cache County,Log01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log05,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log05,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log05,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log06,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log06,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log06,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log07,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log07,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log07,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log08,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log08,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log08,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log09,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log09,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log09,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log10,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log10,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log10,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log11,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log11,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log11,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log12,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log12,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log12,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log13,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log13,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log13,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log14,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log14,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log14,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log15,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log15,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log15,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log16,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log16,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log16,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log17,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log17,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log17,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log18,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log18,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log18,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log19,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log19,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log19,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log20,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log20,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log20,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log21,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log21,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log21,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log22,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log22,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log22,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log23,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log23,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log23,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log24,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log24,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log24,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log25,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log25,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log25,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log26,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log26,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log26,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log27,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log27,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log27,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log28,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log28,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log28,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log29,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log29,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log29,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log30,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log30,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log30,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log31,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log31,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log31,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log32,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log32,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log32,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log33,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log33,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log33,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log33.5,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Log33.5,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Log33.5,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Ama,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Ama,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Ama,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Ben,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Ben,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Ben,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Clk,State House of Representatives,1,CON,Becky Maddox,16
+Cache County,Clk,State House of Representatives,1,DEM,Deloy W. Mecham,38
+Cache County,Clk,State House of Representatives,1,REP,Ronda Rudd Menlove,267
+Cache County,C/Y,State House of Representatives,1,CON,Becky Maddox,
+Cache County,C/Y,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,C/Y,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Cor,State House of Representatives,1,CON,Becky Maddox,10
+Cache County,Cor,State House of Representatives,1,DEM,Deloy W. Mecham,13
+Cache County,Cor,State House of Representatives,1,REP,Ronda Rudd Menlove,95
+Cache County,Cov,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Cov,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Cov,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyd01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyd01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyd01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyd02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyd02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyd02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyr01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyr01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyr01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyr02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyr02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyr02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyr03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyr03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyr03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyr04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyr04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyr04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Hyr05,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Hyr05,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Hyr05,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Lew01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Lew01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Lew01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Lew02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Lew02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Lew02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Men01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Men01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Men01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Men02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Men02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Men02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Mil17,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Mil17,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Mil17,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Mil25,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Mil25,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Mil25,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,New,State House of Representatives,1,CON,Becky Maddox,31
+Cache County,New,State House of Representatives,1,DEM,Deloy W. Mecham,51
+Cache County,New,State House of Representatives,1,REP,Ronda Rudd Menlove,330
+Cache County,Nib01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nib01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nib01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nib03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nib03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nib03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nib17,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nib17,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nib17,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nib25,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nib25,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nib25,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg05,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg05,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg05,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Nlg06,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Nlg06,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Nlg06,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Par,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Par,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Par,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Pro01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Pro01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Pro01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Pro02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Pro02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Pro02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Pro03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Pro03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Pro03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Pro04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Pro04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Pro04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Pro05,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Pro05,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Pro05,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Rch01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Rch01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Rch01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Rch02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Rch02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Rch02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Rvh01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Rvh01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Rvh01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Rvh02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Rvh02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Rvh02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi05,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi05,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi05,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi06,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi06,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi06,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Smi07,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Smi07,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Smi07,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Tre,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Tre,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Tre,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Wel01,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Wel01,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Wel01,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Wel02,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Wel02,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Wel02,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Wel03,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Wel03,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Wel03,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Wel04,State House of Representatives,1,CON,Becky Maddox,
+Cache County,Wel04,State House of Representatives,1,DEM,Deloy W. Mecham,
+Cache County,Wel04,State House of Representatives,1,REP,Ronda Rudd Menlove,
+Cache County,Log01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log03,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log03,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log04,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log04,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log05,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log05,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log06,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log06,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log07,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log07,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log08,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log08,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log09,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log09,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log10,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log10,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log11,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log11,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log12,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log12,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log13,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log13,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log14,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log14,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log15,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log15,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log16,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log16,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log17,State House of Representatives,3,REP,Jack R. Draxler,356
+Cache County,Log17,State House of Representatives,3,DEM,Roger Donohoe,144
+Cache County,Log18,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log18,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log19,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log19,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log20,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log20,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log21,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log21,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log22,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log22,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log23,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log23,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log24,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log24,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log25,State House of Representatives,3,REP,Jack R. Draxler,325
+Cache County,Log25,State House of Representatives,3,DEM,Roger Donohoe,143
+Cache County,Log26,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log26,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log27,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log27,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log28,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log28,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log29,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log29,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log30,State House of Representatives,3,REP,Jack R. Draxler,349
+Cache County,Log30,State House of Representatives,3,DEM,Roger Donohoe,126
+Cache County,Log31,State House of Representatives,3,REP,Jack R. Draxler,344
+Cache County,Log31,State House of Representatives,3,DEM,Roger Donohoe,154
+Cache County,Log32,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log32,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log33,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log33,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log33.5,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Log33.5,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Ama,State House of Representatives,3,REP,Jack R. Draxler,148
+Cache County,Ama,State House of Representatives,3,DEM,Roger Donohoe,58
+Cache County,Ben,State House of Representatives,3,REP,Jack R. Draxler,217
+Cache County,Ben,State House of Representatives,3,DEM,Roger Donohoe,92
+Cache County,Clk,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Clk,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,C/Y,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,C/Y,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Cor,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Cor,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Cov,State House of Representatives,3,REP,Jack R. Draxler,181
+Cache County,Cov,State House of Representatives,3,DEM,Roger Donohoe,55
+Cache County,Hyd01,State House of Representatives,3,REP,Jack R. Draxler,595
+Cache County,Hyd01,State House of Representatives,3,DEM,Roger Donohoe,391
+Cache County,Hyd02,State House of Representatives,3,REP,Jack R. Draxler,546
+Cache County,Hyd02,State House of Representatives,3,DEM,Roger Donohoe,294
+Cache County,Hyr01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Hyr01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Hyr02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Hyr02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Hyr03,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Hyr03,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Hyr04,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Hyr04,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Hyr05,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Hyr05,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Lew01,State House of Representatives,3,REP,Jack R. Draxler,370
+Cache County,Lew01,State House of Representatives,3,DEM,Roger Donohoe,91
+Cache County,Lew02,State House of Representatives,3,REP,Jack R. Draxler,227
+Cache County,Lew02,State House of Representatives,3,DEM,Roger Donohoe,54
+Cache County,Men01,State House of Representatives,3,REP,Jack R. Draxler,55
+Cache County,Men01,State House of Representatives,3,DEM,Roger Donohoe,16
+Cache County,Men02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Men02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Mil17,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Mil17,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Mil25,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Mil25,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,New,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,New,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Nib01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Nib01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Nib03,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Nib03,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Nib17,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Nib17,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Nib25,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Nib25,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Nlg01,State House of Representatives,3,REP,Jack R. Draxler,357
+Cache County,Nlg01,State House of Representatives,3,DEM,Roger Donohoe,154
+Cache County,Nlg02,State House of Representatives,3,REP,Jack R. Draxler,344
+Cache County,Nlg02,State House of Representatives,3,DEM,Roger Donohoe,156
+Cache County,Nlg03,State House of Representatives,3,REP,Jack R. Draxler,364
+Cache County,Nlg03,State House of Representatives,3,DEM,Roger Donohoe,188
+Cache County,Nlg04,State House of Representatives,3,REP,Jack R. Draxler,434
+Cache County,Nlg04,State House of Representatives,3,DEM,Roger Donohoe,182
+Cache County,Nlg05,State House of Representatives,3,REP,Jack R. Draxler,489
+Cache County,Nlg05,State House of Representatives,3,DEM,Roger Donohoe,195
+Cache County,Nlg06,State House of Representatives,3,REP,Jack R. Draxler,377
+Cache County,Nlg06,State House of Representatives,3,DEM,Roger Donohoe,187
+Cache County,Par,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Par,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Pro01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Pro01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Pro02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Pro02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Pro03,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Pro03,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Pro04,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Pro04,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Pro05,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Pro05,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Rch01,State House of Representatives,3,REP,Jack R. Draxler,361
+Cache County,Rch01,State House of Representatives,3,DEM,Roger Donohoe,143
+Cache County,Rch02,State House of Representatives,3,REP,Jack R. Draxler,406
+Cache County,Rch02,State House of Representatives,3,DEM,Roger Donohoe,115
+Cache County,Rvh01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Rvh01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Rvh02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Rvh02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Smi01,State House of Representatives,3,REP,Jack R. Draxler,410
+Cache County,Smi01,State House of Representatives,3,DEM,Roger Donohoe,128
+Cache County,Smi02,State House of Representatives,3,REP,Jack R. Draxler,448
+Cache County,Smi02,State House of Representatives,3,DEM,Roger Donohoe,183
+Cache County,Smi03,State House of Representatives,3,REP,Jack R. Draxler,442
+Cache County,Smi03,State House of Representatives,3,DEM,Roger Donohoe,198
+Cache County,Smi04,State House of Representatives,3,REP,Jack R. Draxler,422
+Cache County,Smi04,State House of Representatives,3,DEM,Roger Donohoe,183
+Cache County,Smi05,State House of Representatives,3,REP,Jack R. Draxler,335
+Cache County,Smi05,State House of Representatives,3,DEM,Roger Donohoe,124
+Cache County,Smi06,State House of Representatives,3,REP,Jack R. Draxler,391
+Cache County,Smi06,State House of Representatives,3,DEM,Roger Donohoe,185
+Cache County,Smi07,State House of Representatives,3,REP,Jack R. Draxler,497
+Cache County,Smi07,State House of Representatives,3,DEM,Roger Donohoe,198
+Cache County,Tre,State House of Representatives,3,REP,Jack R. Draxler,165
+Cache County,Tre,State House of Representatives,3,DEM,Roger Donohoe,48
+Cache County,Wel01,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Wel01,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Wel02,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Wel02,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Wel03,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Wel03,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Wel04,State House of Representatives,3,REP,Jack R. Draxler,
+Cache County,Wel04,State House of Representatives,3,DEM,Roger Donohoe,
+Cache County,Log01,State House of Representatives,4,DEM,Doug Thompson,109
+Cache County,Log01,State House of Representatives,4,REP,Edward Redd,213
+Cache County,Log02,State House of Representatives,4,DEM,Doug Thompson,154
+Cache County,Log02,State House of Representatives,4,REP,Edward Redd,295
+Cache County,Log03,State House of Representatives,4,DEM,Doug Thompson,162
+Cache County,Log03,State House of Representatives,4,REP,Edward Redd,376
+Cache County,Log04,State House of Representatives,4,DEM,Doug Thompson,107
+Cache County,Log04,State House of Representatives,4,REP,Edward Redd,329
+Cache County,Log05,State House of Representatives,4,DEM,Doug Thompson,220
+Cache County,Log05,State House of Representatives,4,REP,Edward Redd,417
+Cache County,Log06,State House of Representatives,4,DEM,Doug Thompson,152
+Cache County,Log06,State House of Representatives,4,REP,Edward Redd,306
+Cache County,Log07,State House of Representatives,4,DEM,Doug Thompson,100
+Cache County,Log07,State House of Representatives,4,REP,Edward Redd,166
+Cache County,Log08,State House of Representatives,4,DEM,Doug Thompson,72
+Cache County,Log08,State House of Representatives,4,REP,Edward Redd,146
+Cache County,Log09,State House of Representatives,4,DEM,Doug Thompson,139
+Cache County,Log09,State House of Representatives,4,REP,Edward Redd,232
+Cache County,Log10,State House of Representatives,4,DEM,Doug Thompson,102
+Cache County,Log10,State House of Representatives,4,REP,Edward Redd,193
+Cache County,Log11,State House of Representatives,4,DEM,Doug Thompson,86
+Cache County,Log11,State House of Representatives,4,REP,Edward Redd,237
+Cache County,Log12,State House of Representatives,4,DEM,Doug Thompson,95
+Cache County,Log12,State House of Representatives,4,REP,Edward Redd,219
+Cache County,Log13,State House of Representatives,4,DEM,Doug Thompson,262
+Cache County,Log13,State House of Representatives,4,REP,Edward Redd,420
+Cache County,Log14,State House of Representatives,4,DEM,Doug Thompson,170
+Cache County,Log14,State House of Representatives,4,REP,Edward Redd,269
+Cache County,Log15,State House of Representatives,4,DEM,Doug Thompson,90
+Cache County,Log15,State House of Representatives,4,REP,Edward Redd,316
+Cache County,Log16,State House of Representatives,4,DEM,Doug Thompson,147
+Cache County,Log16,State House of Representatives,4,REP,Edward Redd,282
+Cache County,Log17,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log17,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log18,State House of Representatives,4,DEM,Doug Thompson,54
+Cache County,Log18,State House of Representatives,4,REP,Edward Redd,338
+Cache County,Log19,State House of Representatives,4,DEM,Doug Thompson,68
+Cache County,Log19,State House of Representatives,4,REP,Edward Redd,264
+Cache County,Log20,State House of Representatives,4,DEM,Doug Thompson,165
+Cache County,Log20,State House of Representatives,4,REP,Edward Redd,495
+Cache County,Log21,State House of Representatives,4,DEM,Doug Thompson,117
+Cache County,Log21,State House of Representatives,4,REP,Edward Redd,296
+Cache County,Log22,State House of Representatives,4,DEM,Doug Thompson,199
+Cache County,Log22,State House of Representatives,4,REP,Edward Redd,523
+Cache County,Log23,State House of Representatives,4,DEM,Doug Thompson,72
+Cache County,Log23,State House of Representatives,4,REP,Edward Redd,323
+Cache County,Log24,State House of Representatives,4,DEM,Doug Thompson,96
+Cache County,Log24,State House of Representatives,4,REP,Edward Redd,161
+Cache County,Log25,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log25,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log26,State House of Representatives,4,DEM,Doug Thompson,116
+Cache County,Log26,State House of Representatives,4,REP,Edward Redd,363
+Cache County,Log27,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log27,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log28,State House of Representatives,4,DEM,Doug Thompson,49
+Cache County,Log28,State House of Representatives,4,REP,Edward Redd,152
+Cache County,Log29,State House of Representatives,4,DEM,Doug Thompson,210
+Cache County,Log29,State House of Representatives,4,REP,Edward Redd,486
+Cache County,Log30,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log30,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log31,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log31,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log32,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log32,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log33,State House of Representatives,4,DEM,Doug Thompson,116
+Cache County,Log33,State House of Representatives,4,REP,Edward Redd,290
+Cache County,Log33.5,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Log33.5,State House of Representatives,4,REP,Edward Redd,
+Cache County,Ama,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Ama,State House of Representatives,4,REP,Edward Redd,
+Cache County,Ben,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Ben,State House of Representatives,4,REP,Edward Redd,
+Cache County,Clk,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Clk,State House of Representatives,4,REP,Edward Redd,
+Cache County,C/Y,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,C/Y,State House of Representatives,4,REP,Edward Redd,
+Cache County,Cor,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Cor,State House of Representatives,4,REP,Edward Redd,
+Cache County,Cov,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Cov,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyd01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyd01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyd02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyd02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyr01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyr01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyr02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyr02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyr03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyr03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyr04,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyr04,State House of Representatives,4,REP,Edward Redd,
+Cache County,Hyr05,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Hyr05,State House of Representatives,4,REP,Edward Redd,
+Cache County,Lew01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Lew01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Lew02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Lew02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Men01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Men01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Men02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Men02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Mil17,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Mil17,State House of Representatives,4,REP,Edward Redd,
+Cache County,Mil25,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Mil25,State House of Representatives,4,REP,Edward Redd,
+Cache County,New,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,New,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nib01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nib01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nib03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nib03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nib17,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nib17,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nib25,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nib25,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg04,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg04,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg05,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg05,State House of Representatives,4,REP,Edward Redd,
+Cache County,Nlg06,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Nlg06,State House of Representatives,4,REP,Edward Redd,
+Cache County,Par,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Par,State House of Representatives,4,REP,Edward Redd,
+Cache County,Pro01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Pro01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Pro02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Pro02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Pro03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Pro03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Pro04,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Pro04,State House of Representatives,4,REP,Edward Redd,
+Cache County,Pro05,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Pro05,State House of Representatives,4,REP,Edward Redd,
+Cache County,Rch01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Rch01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Rch02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Rch02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Rvh01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Rvh01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Rvh02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Rvh02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi04,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi04,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi05,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi05,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi06,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi06,State House of Representatives,4,REP,Edward Redd,
+Cache County,Smi07,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Smi07,State House of Representatives,4,REP,Edward Redd,
+Cache County,Tre,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Tre,State House of Representatives,4,REP,Edward Redd,
+Cache County,Wel01,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Wel01,State House of Representatives,4,REP,Edward Redd,
+Cache County,Wel02,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Wel02,State House of Representatives,4,REP,Edward Redd,
+Cache County,Wel03,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Wel03,State House of Representatives,4,REP,Edward Redd,
+Cache County,Wel04,State House of Representatives,4,DEM,Doug Thompson,
+Cache County,Wel04,State House of Representatives,4,REP,Edward Redd,
+Cache County,Log01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log03,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log03,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log04,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log04,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log05,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log05,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log06,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log06,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log07,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log07,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log08,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log08,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log09,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log09,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log10,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log10,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log11,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log11,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log12,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log12,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log13,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log13,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log14,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log14,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log15,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log15,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log16,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log16,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log17,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log17,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log18,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log18,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log19,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log19,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log20,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log20,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log21,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log21,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log22,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log22,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log23,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log23,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log24,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log24,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log25,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log25,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log26,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log26,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log27,State House of Representatives,5,DEM,Al Snyder,87
+Cache County,Log27,State House of Representatives,5,REP,Curt Webb,390
+Cache County,Log28,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log28,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log29,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log29,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log30,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log30,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log31,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log31,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log32,State House of Representatives,5,DEM,Al Snyder,65
+Cache County,Log32,State House of Representatives,5,REP,Curt Webb,240
+Cache County,Log33,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Log33,State House of Representatives,5,REP,Curt Webb,
+Cache County,Log33.5,State House of Representatives,5,DEM,Al Snyder,26
+Cache County,Log33.5,State House of Representatives,5,REP,Curt Webb,88
+Cache County,Ama,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Ama,State House of Representatives,5,REP,Curt Webb,
+Cache County,Ben,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Ben,State House of Representatives,5,REP,Curt Webb,
+Cache County,Clk,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Clk,State House of Representatives,5,REP,Curt Webb,
+Cache County,C/Y,State House of Representatives,5,DEM,Al Snyder,48
+Cache County,C/Y,State House of Representatives,5,REP,Curt Webb,365
+Cache County,Cor,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Cor,State House of Representatives,5,REP,Curt Webb,
+Cache County,Cov,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Cov,State House of Representatives,5,REP,Curt Webb,
+Cache County,Hyd01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Hyd01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Hyd02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Hyd02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Hyr01,State House of Representatives,5,DEM,Al Snyder,117
+Cache County,Hyr01,State House of Representatives,5,REP,Curt Webb,447
+Cache County,Hyr02,State House of Representatives,5,DEM,Al Snyder,46
+Cache County,Hyr02,State House of Representatives,5,REP,Curt Webb,260
+Cache County,Hyr03,State House of Representatives,5,DEM,Al Snyder,78
+Cache County,Hyr03,State House of Representatives,5,REP,Curt Webb,534
+Cache County,Hyr04,State House of Representatives,5,DEM,Al Snyder,85
+Cache County,Hyr04,State House of Representatives,5,REP,Curt Webb,618
+Cache County,Hyr05,State House of Representatives,5,DEM,Al Snyder,58
+Cache County,Hyr05,State House of Representatives,5,REP,Curt Webb,390
+Cache County,Lew01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Lew01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Lew02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Lew02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Men01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Men01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Men02,State House of Representatives,5,DEM,Al Snyder,171
+Cache County,Men02,State House of Representatives,5,REP,Curt Webb,683
+Cache County,Mil17,State House of Representatives,5,DEM,Al Snyder,20
+Cache County,Mil17,State House of Representatives,5,REP,Curt Webb,84
+Cache County,Mil25,State House of Representatives,5,DEM,Al Snyder,92
+Cache County,Mil25,State House of Representatives,5,REP,Curt Webb,634
+Cache County,New,State House of Representatives,5,DEM,Al Snyder,
+Cache County,New,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nib01,State House of Representatives,5,DEM,Al Snyder,83
+Cache County,Nib01,State House of Representatives,5,REP,Curt Webb,547
+Cache County,Nib03,State House of Representatives,5,DEM,Al Snyder,132
+Cache County,Nib03,State House of Representatives,5,REP,Curt Webb,627
+Cache County,Nib17,State House of Representatives,5,DEM,Al Snyder,75
+Cache County,Nib17,State House of Representatives,5,REP,Curt Webb,486
+Cache County,Nib25,State House of Representatives,5,DEM,Al Snyder,2
+Cache County,Nib25,State House of Representatives,5,REP,Curt Webb,18
+Cache County,Nlg01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nlg02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nlg03,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg03,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nlg04,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg04,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nlg05,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg05,State House of Representatives,5,REP,Curt Webb,
+Cache County,Nlg06,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Nlg06,State House of Representatives,5,REP,Curt Webb,
+Cache County,Par,State House of Representatives,5,DEM,Al Snyder,115
+Cache County,Par,State House of Representatives,5,REP,Curt Webb,627
+Cache County,Pro01,State House of Representatives,5,DEM,Al Snyder,113
+Cache County,Pro01,State House of Representatives,5,REP,Curt Webb,558
+Cache County,Pro02,State House of Representatives,5,DEM,Al Snyder,161
+Cache County,Pro02,State House of Representatives,5,REP,Curt Webb,730
+Cache County,Pro03,State House of Representatives,5,DEM,Al Snyder,79
+Cache County,Pro03,State House of Representatives,5,REP,Curt Webb,553
+Cache County,Pro04,State House of Representatives,5,DEM,Al Snyder,105
+Cache County,Pro04,State House of Representatives,5,REP,Curt Webb,479
+Cache County,Pro05,State House of Representatives,5,DEM,Al Snyder,61
+Cache County,Pro05,State House of Representatives,5,REP,Curt Webb,404
+Cache County,Rch01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Rch01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Rch02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Rch02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Rvh01,State House of Representatives,5,DEM,Al Snyder,93
+Cache County,Rvh01,State House of Representatives,5,REP,Curt Webb,266
+Cache County,Rvh02,State House of Representatives,5,DEM,Al Snyder,98
+Cache County,Rvh02,State House of Representatives,5,REP,Curt Webb,378
+Cache County,Smi01,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi01,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi02,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi02,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi03,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi03,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi04,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi04,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi05,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi05,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi06,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi06,State House of Representatives,5,REP,Curt Webb,
+Cache County,Smi07,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Smi07,State House of Representatives,5,REP,Curt Webb,
+Cache County,Tre,State House of Representatives,5,DEM,Al Snyder,
+Cache County,Tre,State House of Representatives,5,REP,Curt Webb,
+Cache County,Wel01,State House of Representatives,5,DEM,Al Snyder,41
+Cache County,Wel01,State House of Representatives,5,REP,Curt Webb,332
+Cache County,Wel02,State House of Representatives,5,DEM,Al Snyder,69
+Cache County,Wel02,State House of Representatives,5,REP,Curt Webb,444
+Cache County,Wel03,State House of Representatives,5,DEM,Al Snyder,35
+Cache County,Wel03,State House of Representatives,5,REP,Curt Webb,319
+Cache County,Wel04,State House of Representatives,5,DEM,Al Snyder,62
+Cache County,Wel04,State House of Representatives,5,REP,Curt Webb,445


### PR DESCRIPTION
Ref. https://github.com/openelections/openelections-data-ut/issues/29

[This Python script generates a CSV file](https://gist.github.com/migurski/94cb56053c7e97c7e18edb225e2ff8f9) from [input in Google Sheets for Beaver County](https://docs.google.com/spreadsheets/d/1GeV4CvEr2BgbYOtI2MgCHG-Jf8BcY6-nTkYixnKson0/edit#gid=1626096643) and [Cache County](https://docs.google.com/spreadsheets/d/1dtr87swj9byclVH72QimMgr6CR5QAKQQWM7CUP-uEXY/edit#gid=447604816) generated from original county PDF files.

Multi-Page Tables
---

Each office is grouped as one logical table but they're often split up among multiple PDF pages. Here’s an example for House District 2, pages 15-18:

![four-up@1x](https://user-images.githubusercontent.com/58730/73148818-0fe05c00-4073-11ea-8c57-f527e1cf756b.png)

With Tabula and some spreadsheet copy/pasting, it’s useful to get this into an actual single table for this office:

<img width="1278" alt="Screen Shot 2020-01-26 at 7 29 54 PM" src="https://user-images.githubusercontent.com/58730/73148652-4f5a7880-4072-11ea-93b2-bb1cbea28693.png">

Precinct Row Groups
---

Each precinct is expressed as a repeated series of seven rows, with the precinct name followed by polling, absentee, provisional, early, paper at polls, and total vote counts. Only the total vote counts at the end are important for OpenElections:

![one-precinct@2x](https://user-images.githubusercontent.com/58730/73148536-c3485100-4071-11ea-97b6-3587e3828e41.png)

Totals After Precincts
---

After all the precincts, a grand total for the whole county is included in its own set of rows. These should be ignored or they will double the vote counts:

![total-rows@2x](https://user-images.githubusercontent.com/58730/73148538-c5aaab00-4071-11ea-94a3-e220f74f30c7.png)
