### PR TITLE
Remove non-alphanumeric entries

### DIFF
--- a/2014/20141104__ut__general__davis__precinct.csv
+++ b/2014/20141104__ut__general__davis__precinct.csv
@@ -1,7 +1,7 @@
 county,precinct,office,district,party,candidate,votes
 Davis,Bountiful 1,Straight ticket,,Libertarian,,1
 Davis,Bountiful 2,Straight ticket,,Libertarian,,1
-Davis,Bountiful 3,Straight ticket,,Libertarian,,-
+Davis,Bountiful 3,Straight ticket,,Libertarian,,
 Davis,Bountiful 4,Straight ticket,,Libertarian,,2
 Davis,Bountiful 5,Straight ticket,,Libertarian,,2
 Davis,Bountiful 6,Straight ticket,,Libertarian,,1
@@ -11,35 +11,35 @@ Davis,Bountiful 9,Straight ticket,,Libertarian,,2
 Davis,Bountiful 10,Straight ticket,,Libertarian,,1
 Davis,Bountiful 11,Straight ticket,,Libertarian,,2
 Davis,Bountiful 12,Straight ticket,,Libertarian,,3
-Davis,Bountiful 13,Straight ticket,,Libertarian,,-
+Davis,Bountiful 13,Straight ticket,,Libertarian,,
 Davis,Bountiful 14,Straight ticket,,Libertarian,,2
-Davis,Bountiful 15,Straight ticket,,Libertarian,,-
+Davis,Bountiful 15,Straight ticket,,Libertarian,,
 Davis,Bountiful 16,Straight ticket,,Libertarian,,1
-Davis,Bountiful 17,Straight ticket,,Libertarian,,-
-Davis,Bountiful 18,Straight ticket,,Libertarian,,-
+Davis,Bountiful 17,Straight ticket,,Libertarian,,
+Davis,Bountiful 18,Straight ticket,,Libertarian,,
 Davis,Bountiful 19,Straight ticket,,Libertarian,,3
 Davis,Bountiful 20,Straight ticket,,Libertarian,,1
 Davis,Bountiful 21,Straight ticket,,Libertarian,,4
-Davis,Bountiful 22,Straight ticket,,Libertarian,,-
+Davis,Bountiful 22,Straight ticket,,Libertarian,,
 Davis,Bountiful 23,Straight ticket,,Libertarian,,2
-Davis,Bountiful 24,Straight ticket,,Libertarian,,-
+Davis,Bountiful 24,Straight ticket,,Libertarian,,
 Davis,Bountiful 25,Straight ticket,,Libertarian,,2
 Davis,Bountiful 26,Straight ticket,,Libertarian,,3
-Davis,Bountiful 27,Straight ticket,,Libertarian,,-
+Davis,Bountiful 27,Straight ticket,,Libertarian,,
 Davis,Bountiful 28,Straight ticket,,Libertarian,,2
 Davis,Bountiful 29,Straight ticket,,Libertarian,,1
-Davis,Bountiful 30,Straight ticket,,Libertarian,,-
+Davis,Bountiful 30,Straight ticket,,Libertarian,,
 Davis,Bountiful 31,Straight ticket,,Libertarian,,1
 Davis,Centerville 1,Straight ticket,,Libertarian,,1
-Davis,Centerville 2,Straight ticket,,Libertarian,,-
-Davis,Centerville 3,Straight ticket,,Libertarian,,-
+Davis,Centerville 2,Straight ticket,,Libertarian,,
+Davis,Centerville 3,Straight ticket,,Libertarian,,
 Davis,Centerville 4,Straight ticket,,Libertarian,,1
 Davis,Centerville 5,Straight ticket,,Libertarian,,2
-Davis,Centerville 6,Straight ticket,,Libertarian,,-
-Davis,Centerville 7,Straight ticket,,Libertarian,,-
+Davis,Centerville 6,Straight ticket,,Libertarian,,
+Davis,Centerville 7,Straight ticket,,Libertarian,,
 Davis,Centerville 8,Straight ticket,,Libertarian,,1
-Davis,Centerville 9,Straight ticket,,Libertarian,,-
-Davis,Centerville 10,Straight ticket,,Libertarian,,-
+Davis,Centerville 9,Straight ticket,,Libertarian,,
+Davis,Centerville 10,Straight ticket,,Libertarian,,
 Davis,Centerville 11,Straight ticket,,Libertarian,,2
 Davis,Clearfield 1,Straight ticket,,Libertarian,,1
 Davis,Clearfield 2,Straight ticket,,Libertarian,,1
@@ -49,67 +49,67 @@ Davis,Clearfield 5,Straight ticket,,Libertarian,,1
 Davis,Clearfield 6,Straight ticket,,Libertarian,,1
 Davis,Clearfield 7,Straight ticket,,Libertarian,,1
 Davis,Clearfield 8,Straight ticket,,Libertarian,,1
-Davis,Clearfield 9,Straight ticket,,Libertarian,,-
-Davis,Clearfield 10,Straight ticket,,Libertarian,,-
+Davis,Clearfield 9,Straight ticket,,Libertarian,,
+Davis,Clearfield 10,Straight ticket,,Libertarian,,
 Davis,Clearfield 11,Straight ticket,,Libertarian,,2
 Davis,Clearfield 12,Straight ticket,,Libertarian,,2
-Davis,Clearfield 13,Straight ticket,,Libertarian,,-
-Davis,Clearfield 14,Straight ticket,,Libertarian,,-
-Davis,Clearfield 15,Straight ticket,,Libertarian,,-
-Davis,Clinton 1,Straight ticket,,Libertarian,,-
+Davis,Clearfield 13,Straight ticket,,Libertarian,,
+Davis,Clearfield 14,Straight ticket,,Libertarian,,
+Davis,Clearfield 15,Straight ticket,,Libertarian,,
+Davis,Clinton 1,Straight ticket,,Libertarian,,
 Davis,Clinton 2,Straight ticket,,Libertarian,,2
 Davis,Clinton 3,Straight ticket,,Libertarian,,1
-Davis,Clinton 4,Straight ticket,,Libertarian,,-
-Davis,Clinton 5,Straight ticket,,Libertarian,,-
+Davis,Clinton 4,Straight ticket,,Libertarian,,
+Davis,Clinton 5,Straight ticket,,Libertarian,,
 Davis,Clinton 6,Straight ticket,,Libertarian,,3
 Davis,Clinton 7,Straight ticket,,Libertarian,,1
 Davis,Clinton 8,Straight ticket,,Libertarian,,1
 Davis,Clinton 9,Straight ticket,,Libertarian,,2
-Davis,Clinton 10,Straight ticket,,Libertarian,,-
-Davis,Clinton 11,Straight ticket,,Libertarian,,-
-Davis,Clinton 12,Straight ticket,,Libertarian,,-
-Davis,Farmington 1,Straight ticket,,Libertarian,,-
+Davis,Clinton 10,Straight ticket,,Libertarian,,
+Davis,Clinton 11,Straight ticket,,Libertarian,,
+Davis,Clinton 12,Straight ticket,,Libertarian,,
+Davis,Farmington 1,Straight ticket,,Libertarian,,
 Davis,Farmington 2,Straight ticket,,Libertarian,,3
 Davis,Farmington 3,Straight ticket,,Libertarian,,2
-Davis,Farmington 4,Straight ticket,,Libertarian,,-
-Davis,Farmington 5,Straight ticket,,Libertarian,,-
+Davis,Farmington 4,Straight ticket,,Libertarian,,
+Davis,Farmington 5,Straight ticket,,Libertarian,,
 Davis,Farmington 6,Straight ticket,,Libertarian,,3
 Davis,Farmington 7,Straight ticket,,Libertarian,,1
 Davis,Farmington 8,Straight ticket,,Libertarian,,1
 Davis,Farmington 9,Straight ticket,,Libertarian,,2
 Davis,Farmington 10,Straight ticket,,Libertarian,,2
 Davis,Farmington 11,Straight ticket,,Libertarian,,1
-Davis,Farmington 12,Straight ticket,,Libertarian,,-
+Davis,Farmington 12,Straight ticket,,Libertarian,,
 Davis,Farmington 13,Straight ticket,,Libertarian,,1
 Davis,Fruit Heights 1,Straight ticket,,Libertarian,,1
 Davis,Fruit Heights 2,Straight ticket,,Libertarian,,1
 Davis,Fruit Heights 3,Straight ticket,,Libertarian,,3
-Davis,Fruit Heights 4,Straight ticket,,Libertarian,,-
-Davis,Hill AFB 1,Straight ticket,,Libertarian,,-
-Davis,Hill AFB 2,Straight ticket,,Libertarian,,-
+Davis,Fruit Heights 4,Straight ticket,,Libertarian,,
+Davis,Hill AFB 1,Straight ticket,,Libertarian,,
+Davis,Hill AFB 2,Straight ticket,,Libertarian,,
 Davis,Kaysville 1,Straight ticket,,Libertarian,,1
 Davis,Kaysville 2,Straight ticket,,Libertarian,,2
-Davis,Kaysville 3,Straight ticket,,Libertarian,,-
+Davis,Kaysville 3,Straight ticket,,Libertarian,,
 Davis,Kaysville 4,Straight ticket,,Libertarian,,2
-Davis,Kaysville 5,Straight ticket,,Libertarian,,-
+Davis,Kaysville 5,Straight ticket,,Libertarian,,
 Davis,Kaysville 6,Straight ticket,,Libertarian,,3
 Davis,Kaysville 7,Straight ticket,,Libertarian,,1
-Davis,Kaysville 8,Straight ticket,,Libertarian,,-
-Davis,Kaysville 9,Straight ticket,,Libertarian,,-
+Davis,Kaysville 8,Straight ticket,,Libertarian,,
+Davis,Kaysville 9,Straight ticket,,Libertarian,,
 Davis,Kaysville 10,Straight ticket,,Libertarian,,4
-Davis,Kaysville 11,Straight ticket,,Libertarian,,-
+Davis,Kaysville 11,Straight ticket,,Libertarian,,
 Davis,Kaysville 12,Straight ticket,,Libertarian,,1
 Davis,Kaysville 13,Straight ticket,,Libertarian,,1
 Davis,Kaysville 14,Straight ticket,,Libertarian,,1
 Davis,Kaysville 15,Straight ticket,,Libertarian,,1
 Davis,Kaysville 16,Straight ticket,,Libertarian,,1
-Davis,Kaysville 17,Straight ticket,,Libertarian,,-
-Davis,Kaysville 18,Straight ticket,,Libertarian,,-
-Davis,Kaysville 19,Straight ticket,,Libertarian,,-
+Davis,Kaysville 17,Straight ticket,,Libertarian,,
+Davis,Kaysville 18,Straight ticket,,Libertarian,,
+Davis,Kaysville 19,Straight ticket,,Libertarian,,
 Davis,Layton 1,Straight ticket,,Libertarian,,2
 Davis,Layton 2,Straight ticket,,Libertarian,,2
 Davis,Layton 3,Straight ticket,,Libertarian,,1
-Davis,Layton 4,Straight ticket,,Libertarian,,-
+Davis,Layton 4,Straight ticket,,Libertarian,,
 Davis,Layton 5,Straight ticket,,Libertarian,,1
 Davis,Layton 6,Straight ticket,,Libertarian,,3
 Davis,Layton 7,Straight ticket,,Libertarian,,5
@@ -131,39 +131,39 @@ Davis,Layton 22,Straight ticket,,Libertarian,,2
 Davis,Layton 23,Straight ticket,,Libertarian,,2
 Davis,Layton 24,Straight ticket,,Libertarian,,3
 Davis,Layton 25,Straight ticket,,Libertarian,,2
-Davis,Layton 26,Straight ticket,,Libertarian,,-
-Davis,Layton 27,Straight ticket,,Libertarian,,-
+Davis,Layton 26,Straight ticket,,Libertarian,,
+Davis,Layton 27,Straight ticket,,Libertarian,,
 Davis,Layton 28,Straight ticket,,Libertarian,,2
 Davis,Layton 29,Straight ticket,,Libertarian,,2
 Davis,Layton 30,Straight ticket,,Libertarian,,1
 Davis,Layton 31,Straight ticket,,Libertarian,,1
 Davis,Layton 32,Straight ticket,,Libertarian,,1
-Davis,Layton 33,Straight ticket,,Libertarian,,-
+Davis,Layton 33,Straight ticket,,Libertarian,,
 Davis,Layton 34,Straight ticket,,Libertarian,,2
 Davis,Layton 35,Straight ticket,,Libertarian,,1
 Davis,Layton 36,Straight ticket,,Libertarian,,1
 Davis,Layton 37,Straight ticket,,Libertarian,,3
 Davis,Layton 38,Straight ticket,,Libertarian,,3
-Davis,Layton 39,Straight ticket,,Libertarian,,-
-Davis,Layton 40,Straight ticket,,Libertarian,,-
+Davis,Layton 39,Straight ticket,,Libertarian,,
+Davis,Layton 40,Straight ticket,,Libertarian,,
 Davis,Layton 41,Straight ticket,,Libertarian,,1
 Davis,Layton 42,Straight ticket,,Libertarian,,2
 Davis,Layton 43,Straight ticket,,Libertarian,,1
-Davis,Layton 44,Straight ticket,,Libertarian,,-
+Davis,Layton 44,Straight ticket,,Libertarian,,
 Davis,North Salt Lake 1,Straight ticket,,Libertarian,,3
 Davis,North Salt Lake 2,Straight ticket,,Libertarian,,1
-Davis,North Salt Lake 3,Straight ticket,,Libertarian,,-
-Davis,North Salt Lake 4,Straight ticket,,Libertarian,,-
+Davis,North Salt Lake 3,Straight ticket,,Libertarian,,
+Davis,North Salt Lake 4,Straight ticket,,Libertarian,,
 Davis,North Salt Lake 5,Straight ticket,,Libertarian,,1
 Davis,North Salt Lake 6,Straight ticket,,Libertarian,,1
-Davis,North Salt Lake 7,Straight ticket,,Libertarian,,-
-Davis,North Salt Lake 8,Straight ticket,,Libertarian,,-
-Davis,North Salt Lake 9,Straight ticket,,Libertarian,,-
-Davis,North Salt Lake 10,Straight ticket,,Libertarian,,-
+Davis,North Salt Lake 7,Straight ticket,,Libertarian,,
+Davis,North Salt Lake 8,Straight ticket,,Libertarian,,
+Davis,North Salt Lake 9,Straight ticket,,Libertarian,,
+Davis,North Salt Lake 10,Straight ticket,,Libertarian,,
 Davis,South Weber 1,Straight ticket,,Libertarian,,2
-Davis,South Weber 2,Straight ticket,,Libertarian,,-
+Davis,South Weber 2,Straight ticket,,Libertarian,,
 Davis,South Weber 3,Straight ticket,,Libertarian,,4
-Davis,South Weber 4,Straight ticket,,Libertarian,,-
+Davis,South Weber 4,Straight ticket,,Libertarian,,
 Davis,Sunset 1,Straight ticket,,Libertarian,,4
 Davis,Sunset 2,Straight ticket,,Libertarian,,1
 Davis,Sunset 3,Straight ticket,,Libertarian,,3
@@ -171,38 +171,38 @@ Davis,Syracuse 1,Straight ticket,,Libertarian,,1
 Davis,Syracuse 2,Straight ticket,,Libertarian,,2
 Davis,Syracuse 3,Straight ticket,,Libertarian,,2
 Davis,Syracuse 4,Straight ticket,,Libertarian,,1
-Davis,Syracuse 5,Straight ticket,,Libertarian,,-
-Davis,Syracuse 6,Straight ticket,,Libertarian,,-
+Davis,Syracuse 5,Straight ticket,,Libertarian,,
+Davis,Syracuse 6,Straight ticket,,Libertarian,,
 Davis,Syracuse 7,Straight ticket,,Libertarian,,1
 Davis,Syracuse 8,Straight ticket,,Libertarian,,2
 Davis,Syracuse 9,Straight ticket,,Libertarian,,2
 Davis,Syracuse 10,Straight ticket,,Libertarian,,1
-Davis,Syracuse 11,Straight ticket,,Libertarian,,-
+Davis,Syracuse 11,Straight ticket,,Libertarian,,
 Davis,Syracuse 12,Straight ticket,,Libertarian,,1
 Davis,Syracuse 13,Straight ticket,,Libertarian,,2
-Davis,Syracuse 14,Straight ticket,,Libertarian,,-
+Davis,Syracuse 14,Straight ticket,,Libertarian,,
 Davis,West Bountiful 1,Straight ticket,,Libertarian,,2
-Davis,West Bountiful 2,Straight ticket,,Libertarian,,-
+Davis,West Bountiful 2,Straight ticket,,Libertarian,,
 Davis,West Bountiful 3,Straight ticket,,Libertarian,,2
 Davis,West Bountiful 4,Straight ticket,,Libertarian,,1
-Davis,West Point 1,Straight ticket,,Libertarian,,-
-Davis,West Point 2,Straight ticket,,Libertarian,,-
-Davis,West Point 3,Straight ticket,,Libertarian,,-
+Davis,West Point 1,Straight ticket,,Libertarian,,
+Davis,West Point 2,Straight ticket,,Libertarian,,
+Davis,West Point 3,Straight ticket,,Libertarian,,
 Davis,West Point 4,Straight ticket,,Libertarian,,1
 Davis,West Point 5,Straight ticket,,Libertarian,,1
-Davis,West Point 6,Straight ticket,,Libertarian,,-
-Davis,West Point 7,Straight ticket,,Libertarian,,-
-Davis,Woods Cross 1,Straight ticket,,Libertarian,,-
+Davis,West Point 6,Straight ticket,,Libertarian,,
+Davis,West Point 7,Straight ticket,,Libertarian,,
+Davis,Woods Cross 1,Straight ticket,,Libertarian,,
 Davis,Woods Cross 2,Straight ticket,,Libertarian,,3
-Davis,Woods Cross 3,Straight ticket,,Libertarian,,-
-Davis,Woods Cross 4,Straight ticket,,Libertarian,,-
-Davis,Woods Cross 5,Straight ticket,,Libertarian,,-
+Davis,Woods Cross 3,Straight ticket,,Libertarian,,
+Davis,Woods Cross 4,Straight ticket,,Libertarian,,
+Davis,Woods Cross 5,Straight ticket,,Libertarian,,
 Davis,Woods Cross 6,Straight ticket,,Libertarian,,1
 Davis,Bountiful 1,Straight ticket,,Independent American,,2
 Davis,Bountiful 2,Straight ticket,,Independent American,,5
 Davis,Bountiful 3,Straight ticket,,Independent American,,2
 Davis,Bountiful 4,Straight ticket,,Independent American,,1
-Davis,Bountiful 5,Straight ticket,,Independent American,,-
+Davis,Bountiful 5,Straight ticket,,Independent American,,
 Davis,Bountiful 6,Straight ticket,,Independent American,,1
 Davis,Bountiful 7,Straight ticket,,Independent American,,4
 Davis,Bountiful 8,Straight ticket,,Independent American,,5
@@ -226,16 +226,16 @@ Davis,Bountiful 25,Straight ticket,,Independent American,,2
 Davis,Bountiful 26,Straight ticket,,Independent American,,1
 Davis,Bountiful 27,Straight ticket,,Independent American,,2
 Davis,Bountiful 28,Straight ticket,,Independent American,,2
-Davis,Bountiful 29,Straight ticket,,Independent American,,-
+Davis,Bountiful 29,Straight ticket,,Independent American,,
 Davis,Bountiful 30,Straight ticket,,Independent American,,2
-Davis,Bountiful 31,Straight ticket,,Independent American,,-
+Davis,Bountiful 31,Straight ticket,,Independent American,,
 Davis,Centerville 1,Straight ticket,,Independent American,,2
 Davis,Centerville 2,Straight ticket,,Independent American,,2
-Davis,Centerville 3,Straight ticket,,Independent American,,-
+Davis,Centerville 3,Straight ticket,,Independent American,,
 Davis,Centerville 4,Straight ticket,,Independent American,,6
 Davis,Centerville 5,Straight ticket,,Independent American,,3
 Davis,Centerville 6,Straight ticket,,Independent American,,4
-Davis,Centerville 7,Straight ticket,,Independent American,,-
+Davis,Centerville 7,Straight ticket,,Independent American,,
 Davis,Centerville 8,Straight ticket,,Independent American,,1
 Davis,Centerville 9,Straight ticket,,Independent American,,3
 Davis,Centerville 10,Straight ticket,,Independent American,,2
@@ -251,13 +251,13 @@ Davis,Clearfield 8,Straight ticket,,Independent American,,3
 Davis,Clearfield 9,Straight ticket,,Independent American,,1
 Davis,Clearfield 10,Straight ticket,,Independent American,,4
 Davis,Clearfield 11,Straight ticket,,Independent American,,3
-Davis,Clearfield 12,Straight ticket,,Independent American,,-
-Davis,Clearfield 13,Straight ticket,,Independent American,,-
-Davis,Clearfield 14,Straight ticket,,Independent American,,-
-Davis,Clearfield 15,Straight ticket,,Independent American,,-
+Davis,Clearfield 12,Straight ticket,,Independent American,,
+Davis,Clearfield 13,Straight ticket,,Independent American,,
+Davis,Clearfield 14,Straight ticket,,Independent American,,
+Davis,Clearfield 15,Straight ticket,,Independent American,,
 Davis,Clinton 1,Straight ticket,,Independent American,,3
 Davis,Clinton 2,Straight ticket,,Independent American,,4
-Davis,Clinton 3,Straight ticket,,Independent American,,-
+Davis,Clinton 3,Straight ticket,,Independent American,,
 Davis,Clinton 4,Straight ticket,,Independent American,,2
 Davis,Clinton 5,Straight ticket,,Independent American,,1
 Davis,Clinton 6,Straight ticket,,Independent American,,5
@@ -284,48 +284,48 @@ Davis,Fruit Heights 1,Straight ticket,,Independent American,,2
 Davis,Fruit Heights 2,Straight ticket,,Independent American,,1
 Davis,Fruit Heights 3,Straight ticket,,Independent American,,4
 Davis,Fruit Heights 4,Straight ticket,,Independent American,,2
-Davis,Hill AFB 1,Straight ticket,,Independent American,,-
-Davis,Hill AFB 2,Straight ticket,,Independent American,,-
-Davis,Kaysville 1,Straight ticket,,Independent American,,-
+Davis,Hill AFB 1,Straight ticket,,Independent American,,
+Davis,Hill AFB 2,Straight ticket,,Independent American,,
+Davis,Kaysville 1,Straight ticket,,Independent American,,
 Davis,Kaysville 2,Straight ticket,,Independent American,,4
-Davis,Kaysville 3,Straight ticket,,Independent American,,-
+Davis,Kaysville 3,Straight ticket,,Independent American,,
 Davis,Kaysville 4,Straight ticket,,Independent American,,1
 Davis,Kaysville 5,Straight ticket,,Independent American,,7
 Davis,Kaysville 6,Straight ticket,,Independent American,,1
 Davis,Kaysville 7,Straight ticket,,Independent American,,3
 Davis,Kaysville 8,Straight ticket,,Independent American,,3
-Davis,Kaysville 9,Straight ticket,,Independent American,,-
+Davis,Kaysville 9,Straight ticket,,Independent American,,
 Davis,Kaysville 10,Straight ticket,,Independent American,,9
 Davis,Kaysville 11,Straight ticket,,Independent American,,3
 Davis,Kaysville 12,Straight ticket,,Independent American,,2
 Davis,Kaysville 13,Straight ticket,,Independent American,,1
 Davis,Kaysville 14,Straight ticket,,Independent American,,3
 Davis,Kaysville 15,Straight ticket,,Independent American,,2
-Davis,Kaysville 16,Straight ticket,,Independent American,,-
-Davis,Kaysville 17,Straight ticket,,Independent American,,-
+Davis,Kaysville 16,Straight ticket,,Independent American,,
+Davis,Kaysville 17,Straight ticket,,Independent American,,
 Davis,Kaysville 18,Straight ticket,,Independent American,,1
-Davis,Kaysville 19,Straight ticket,,Independent American,,-
-Davis,Layton 1,Straight ticket,,Independent American,,-
-Davis,Layton 2,Straight ticket,,Independent American,,-
-Davis,Layton 3,Straight ticket,,Independent American,,-
+Davis,Kaysville 19,Straight ticket,,Independent American,,
+Davis,Layton 1,Straight ticket,,Independent American,,
+Davis,Layton 2,Straight ticket,,Independent American,,
+Davis,Layton 3,Straight ticket,,Independent American,,
 Davis,Layton 4,Straight ticket,,Independent American,,3
 Davis,Layton 5,Straight ticket,,Independent American,,3
-Davis,Layton 6,Straight ticket,,Independent American,,-
+Davis,Layton 6,Straight ticket,,Independent American,,
 Davis,Layton 7,Straight ticket,,Independent American,,3
 Davis,Layton 8,Straight ticket,,Independent American,,3
-Davis,Layton 9,Straight ticket,,Independent American,,-
+Davis,Layton 9,Straight ticket,,Independent American,,
 Davis,Layton 10,Straight ticket,,Independent American,,7
 Davis,Layton 11,Straight ticket,,Independent American,,2
 Davis,Layton 12,Straight ticket,,Independent American,,5
 Davis,Layton 13,Straight ticket,,Independent American,,3
 Davis,Layton 14,Straight ticket,,Independent American,,2
-Davis,Layton 15,Straight ticket,,Independent American,,-
+Davis,Layton 15,Straight ticket,,Independent American,,
 Davis,Layton 16,Straight ticket,,Independent American,,1
 Davis,Layton 17,Straight ticket,,Independent American,,3
 Davis,Layton 18,Straight ticket,,Independent American,,1
 Davis,Layton 19,Straight ticket,,Independent American,,1
 Davis,Layton 20,Straight ticket,,Independent American,,1
-Davis,Layton 21,Straight ticket,,Independent American,,-
+Davis,Layton 21,Straight ticket,,Independent American,,
 Davis,Layton 22,Straight ticket,,Independent American,,3
 Davis,Layton 23,Straight ticket,,Independent American,,4
 Davis,Layton 24,Straight ticket,,Independent American,,2
@@ -356,30 +356,30 @@ Davis,North Salt Lake 4,Straight ticket,,Independent American,,3
 Davis,North Salt Lake 5,Straight ticket,,Independent American,,2
 Davis,North Salt Lake 6,Straight ticket,,Independent American,,1
 Davis,North Salt Lake 7,Straight ticket,,Independent American,,3
-Davis,North Salt Lake 8,Straight ticket,,Independent American,,-
+Davis,North Salt Lake 8,Straight ticket,,Independent American,,
 Davis,North Salt Lake 9,Straight ticket,,Independent American,,2
 Davis,North Salt Lake 10,Straight ticket,,Independent American,,1
 Davis,South Weber 1,Straight ticket,,Independent American,,6
 Davis,South Weber 2,Straight ticket,,Independent American,,3
 Davis,South Weber 3,Straight ticket,,Independent American,,4
-Davis,South Weber 4,Straight ticket,,Independent American,,-
+Davis,South Weber 4,Straight ticket,,Independent American,,
 Davis,Sunset 1,Straight ticket,,Independent American,,4
 Davis,Sunset 2,Straight ticket,,Independent American,,1
 Davis,Sunset 3,Straight ticket,,Independent American,,3
 Davis,Syracuse 1,Straight ticket,,Independent American,,3
 Davis,Syracuse 2,Straight ticket,,Independent American,,1
-Davis,Syracuse 3,Straight ticket,,Independent American,,-
+Davis,Syracuse 3,Straight ticket,,Independent American,,
 Davis,Syracuse 4,Straight ticket,,Independent American,,2
 Davis,Syracuse 5,Straight ticket,,Independent American,,4
 Davis,Syracuse 6,Straight ticket,,Independent American,,5
 Davis,Syracuse 7,Straight ticket,,Independent American,,2
 Davis,Syracuse 8,Straight ticket,,Independent American,,3
 Davis,Syracuse 9,Straight ticket,,Independent American,,4
-Davis,Syracuse 10,Straight ticket,,Independent American,,-
-Davis,Syracuse 11,Straight ticket,,Independent American,,-
+Davis,Syracuse 10,Straight ticket,,Independent American,,
+Davis,Syracuse 11,Straight ticket,,Independent American,,
 Davis,Syracuse 12,Straight ticket,,Independent American,,3
 Davis,Syracuse 13,Straight ticket,,Independent American,,1
-Davis,Syracuse 14,Straight ticket,,Independent American,,-
+Davis,Syracuse 14,Straight ticket,,Independent American,,
 Davis,West Bountiful 1,Straight ticket,,Independent American,,1
 Davis,West Bountiful 2,Straight ticket,,Independent American,,5
 Davis,West Bountiful 3,Straight ticket,,Independent American,,3
@@ -390,7 +390,7 @@ Davis,West Point 3,Straight ticket,,Independent American,,4
 Davis,West Point 4,Straight ticket,,Independent American,,1
 Davis,West Point 5,Straight ticket,,Independent American,,1
 Davis,West Point 6,Straight ticket,,Independent American,,5
-Davis,West Point 7,Straight ticket,,Independent American,,-
+Davis,West Point 7,Straight ticket,,Independent American,,
 Davis,Woods Cross 1,Straight ticket,,Independent American,,2
 Davis,Woods Cross 2,Straight ticket,,Independent American,,2
 Davis,Woods Cross 3,Straight ticket,,Independent American,,3
@@ -484,7 +484,7 @@ Davis,Fruit Heights 2,Straight ticket,,Republican,,122
 Davis,Fruit Heights 3,Straight ticket,,Republican,,154
 Davis,Fruit Heights 4,Straight ticket,,Republican,,117
 Davis,Hill AFB 1,Straight ticket,,Republican,,6
-Davis,Hill AFB 2,Straight ticket,,Republican,,-
+Davis,Hill AFB 2,Straight ticket,,Republican,,
 Davis,Kaysville 1,Straight ticket,,Republican,,113
 Davis,Kaysville 2,Straight ticket,,Republican,,94
 Davis,Kaysville 3,Straight ticket,,Republican,,93
@@ -561,7 +561,7 @@ Davis,North Salt Lake 10,Straight ticket,,Republican,,47
 Davis,South Weber 1,Straight ticket,,Republican,,87
 Davis,South Weber 2,Straight ticket,,Republican,,105
 Davis,South Weber 3,Straight ticket,,Republican,,165
-Davis,South Weber 4,Straight ticket,,Republican,,-
+Davis,South Weber 4,Straight ticket,,Republican,,
 Davis,Sunset 1,Straight ticket,,Republican,,43
 Davis,Sunset 2,Straight ticket,,Republican,,45
 Davis,Sunset 3,Straight ticket,,Republican,,65
@@ -598,7 +598,7 @@ Davis,Woods Cross 5,Straight ticket,,Republican,,57
 Davis,Woods Cross 6,Straight ticket,,Republican,,81
 Davis,Bountiful 1,Straight ticket,,Constitution,,1
 Davis,Bountiful 2,Straight ticket,,Constitution,,1
-Davis,Bountiful 3,Straight ticket,,Constitution,,-
+Davis,Bountiful 3,Straight ticket,,Constitution,,
 Davis,Bountiful 4,Straight ticket,,Constitution,,2
 Davis,Bountiful 5,Straight ticket,,Constitution,,3
 Davis,Bountiful 6,Straight ticket,,Constitution,,1
@@ -619,7 +619,7 @@ Davis,Bountiful 20,Straight ticket,,Constitution,,1
 Davis,Bountiful 21,Straight ticket,,Constitution,,2
 Davis,Bountiful 22,Straight ticket,,Constitution,,1
 Davis,Bountiful 23,Straight ticket,,Constitution,,1
-Davis,Bountiful 24,Straight ticket,,Constitution,,-
+Davis,Bountiful 24,Straight ticket,,Constitution,,
 Davis,Bountiful 25,Straight ticket,,Constitution,,2
 Davis,Bountiful 26,Straight ticket,,Constitution,,1
 Davis,Bountiful 27,Straight ticket,,Constitution,,
@@ -849,7 +849,7 @@ Davis,Clearfield 9,Straight ticket,,Democratic,,26
 Davis,Clearfield 10,Straight ticket,,Democratic,,28
 Davis,Clearfield 11,Straight ticket,,Democratic,,39
 Davis,Clearfield 12,Straight ticket,,Democratic,,38
-Davis,Clearfield 13,Straight ticket,,Democratic,,-
+Davis,Clearfield 13,Straight ticket,,Democratic,,
 Davis,Clearfield 14,Straight ticket,,Democratic,,1
 Davis,Clearfield 15,Straight ticket,,Democratic,,1
 Davis,Clinton 1,Straight ticket,,Democratic,,21
@@ -882,7 +882,7 @@ Davis,Fruit Heights 2,Straight ticket,,Democratic,,16
 Davis,Fruit Heights 3,Straight ticket,,Democratic,,16
 Davis,Fruit Heights 4,Straight ticket,,Democratic,,13
 Davis,Hill AFB 1,Straight ticket,,Democratic,,2
-Davis,Hill AFB 2,Straight ticket,,Democratic,,-
+Davis,Hill AFB 2,Straight ticket,,Democratic,,
 Davis,Kaysville 1,Straight ticket,,Democratic,,21
 Davis,Kaysville 2,Straight ticket,,Democratic,,20
 Davis,Kaysville 3,Straight ticket,,Democratic,,17
@@ -1026,7 +1026,7 @@ Davis,Fruit Heights 2,U.S. House,1,,Donna McAleer,72
 Davis,Fruit Heights 3,U.S. House,1,,Donna McAleer,93
 Davis,Fruit Heights 4,U.S. House,1,,Donna McAleer,57
 Davis,Hill AFB 1,U.S. House,1,,Donna McAleer,4
-Davis,Hill AFB 2,U.S. House,1,,Donna McAleer,-
+Davis,Hill AFB 2,U.S. House,1,,Donna McAleer,
 Davis,Kaysville 1,U.S. House,1,,Donna McAleer,86
 Davis,Kaysville 2,U.S. House,1,,Donna McAleer,69
 Davis,Kaysville 3,U.S. House,1,,Donna McAleer,61
@@ -1130,8 +1130,8 @@ Davis,Clearfield 10,U.S. House,1,,Dwayne A Vance,12
 Davis,Clearfield 11,U.S. House,1,,Dwayne A Vance,11
 Davis,Clearfield 12,U.S. House,1,,Dwayne A Vance,14
 Davis,Clearfield 13,U.S. House,1,,Dwayne A Vance,1
-Davis,Clearfield 14,U.S. House,1,,Dwayne A Vance,-
-Davis,Clearfield 15,U.S. House,1,,Dwayne A Vance,-
+Davis,Clearfield 14,U.S. House,1,,Dwayne A Vance,
+Davis,Clearfield 15,U.S. House,1,,Dwayne A Vance,
 Davis,Clinton 1,U.S. House,1,,Dwayne A Vance,15
 Davis,Clinton 2,U.S. House,1,,Dwayne A Vance,18
 Davis,Clinton 3,U.S. House,1,,Dwayne A Vance,4
@@ -1148,8 +1148,8 @@ Davis,Fruit Heights 1,U.S. House,1,,Dwayne A Vance,11
 Davis,Fruit Heights 2,U.S. House,1,,Dwayne A Vance,14
 Davis,Fruit Heights 3,U.S. House,1,,Dwayne A Vance,8
 Davis,Fruit Heights 4,U.S. House,1,,Dwayne A Vance,4
-Davis,Hill AFB 1,U.S. House,1,,Dwayne A Vance,-
-Davis,Hill AFB 2,U.S. House,1,,Dwayne A Vance,-
+Davis,Hill AFB 1,U.S. House,1,,Dwayne A Vance,
+Davis,Hill AFB 2,U.S. House,1,,Dwayne A Vance,
 Davis,Kaysville 1,U.S. House,1,,Dwayne A Vance,23
 Davis,Kaysville 2,U.S. House,1,,Dwayne A Vance,20
 Davis,Kaysville 3,U.S. House,1,,Dwayne A Vance,12
@@ -1215,7 +1215,7 @@ Davis,Layton 44,U.S. House,1,,Dwayne A Vance,10
 Davis,South Weber 1,U.S. House,1,,Dwayne A Vance,16
 Davis,South Weber 2,U.S. House,1,,Dwayne A Vance,14
 Davis,South Weber 3,U.S. House,1,,Dwayne A Vance,22
-Davis,South Weber 4,U.S. House,1,,Dwayne A Vance,-
+Davis,South Weber 4,U.S. House,1,,Dwayne A Vance,
 Davis,Sunset 1,U.S. House,1,,Dwayne A Vance,4
 Davis,Sunset 2,U.S. House,1,,Dwayne A Vance,6
 Davis,Sunset 3,U.S. House,1,,Dwayne A Vance,12
@@ -1272,7 +1272,7 @@ Davis,Fruit Heights 2,U.S. House,1,,Rob Bishop,308
 Davis,Fruit Heights 3,U.S. House,1,,Rob Bishop,370
 Davis,Fruit Heights 4,U.S. House,1,,Rob Bishop,293
 Davis,Hill AFB 1,U.S. House,1,,Rob Bishop,6
-Davis,Hill AFB 2,U.S. House,1,,Rob Bishop,-
+Davis,Hill AFB 2,U.S. House,1,,Rob Bishop,
 Davis,Kaysville 1,U.S. House,1,,Rob Bishop,300
 Davis,Kaysville 2,U.S. House,1,,Rob Bishop,366
 Davis,Kaysville 3,U.S. House,1,,Rob Bishop,314
@@ -1338,7 +1338,7 @@ Davis,Layton 44,U.S. House,1,,Rob Bishop,178
 Davis,South Weber 1,U.S. House,1,,Rob Bishop,235
 Davis,South Weber 2,U.S. House,1,,Rob Bishop,264
 Davis,South Weber 3,U.S. House,1,,Rob Bishop,351
-Davis,South Weber 4,U.S. House,1,,Rob Bishop,-
+Davis,South Weber 4,U.S. House,1,,Rob Bishop,
 Davis,Sunset 1,U.S. House,1,,Rob Bishop,80
 Davis,Sunset 2,U.S. House,1,,Rob Bishop,126
 Davis,Sunset 3,U.S. House,1,,Rob Bishop,164
@@ -1377,7 +1377,7 @@ Davis,Clearfield 11,U.S. House,1,,Craig Bowden,15
 Davis,Clearfield 12,U.S. House,1,,Craig Bowden,11
 Davis,Clearfield 13,U.S. House,1,,Craig Bowden,2
 Davis,Clearfield 14,U.S. House,1,,Craig Bowden,1
-Davis,Clearfield 15,U.S. House,1,,Craig Bowden,-
+Davis,Clearfield 15,U.S. House,1,,Craig Bowden,
 Davis,Clinton 1,U.S. House,1,,Craig Bowden,10
 Davis,Clinton 2,U.S. House,1,,Craig Bowden,16
 Davis,Clinton 3,U.S. House,1,,Craig Bowden,3
@@ -1394,8 +1394,8 @@ Davis,Fruit Heights 1,U.S. House,1,,Craig Bowden,13
 Davis,Fruit Heights 2,U.S. House,1,,Craig Bowden,14
 Davis,Fruit Heights 3,U.S. House,1,,Craig Bowden,17
 Davis,Fruit Heights 4,U.S. House,1,,Craig Bowden,3
-Davis,Hill AFB 1,U.S. House,1,,Craig Bowden,-
-Davis,Hill AFB 2,U.S. House,1,,Craig Bowden,-
+Davis,Hill AFB 1,U.S. House,1,,Craig Bowden,
+Davis,Hill AFB 2,U.S. House,1,,Craig Bowden,
 Davis,Kaysville 1,U.S. House,1,,Craig Bowden,20
 Davis,Kaysville 2,U.S. House,1,,Craig Bowden,16
 Davis,Kaysville 3,U.S. House,1,,Craig Bowden,9
@@ -1461,7 +1461,7 @@ Davis,Layton 44,U.S. House,1,,Craig Bowden,5
 Davis,South Weber 1,U.S. House,1,,Craig Bowden,13
 Davis,South Weber 2,U.S. House,1,,Craig Bowden,12
 Davis,South Weber 3,U.S. House,1,,Craig Bowden,15
-Davis,South Weber 4,U.S. House,1,,Craig Bowden,-
+Davis,South Weber 4,U.S. House,1,,Craig Bowden,
 Davis,Sunset 1,U.S. House,1,,Craig Bowden,8
 Davis,Sunset 2,U.S. House,1,,Craig Bowden,20
 Davis,Sunset 3,U.S. House,1,,Craig Bowden,15
@@ -1615,7 +1615,7 @@ Davis,Farmington 8,U.S. House,2,,Wayne L. Hill,4
 Davis,Farmington 9,U.S. House,2,,Wayne L. Hill,9
 Davis,Farmington 10,U.S. House,2,,Wayne L. Hill,8
 Davis,Farmington 11,U.S. House,2,,Wayne L. Hill,11
-Davis,Farmington 12,U.S. House,2,,Wayne L. Hill,-
+Davis,Farmington 12,U.S. House,2,,Wayne L. Hill,
 Davis,Farmington 13,U.S. House,2,,Wayne L. Hill,6
 Davis,Kaysville 15,U.S. House,2,,Wayne L. Hill,9
 Davis,North Salt Lake 1,U.S. House,2,,Wayne L. Hill,4
@@ -1806,14 +1806,14 @@ Davis,Bountiful 13,U.S. House,2,,Bill Barron,3
 Davis,Bountiful 14,U.S. House,2,,Bill Barron,3
 Davis,Bountiful 15,U.S. House,2,,Bill Barron,4
 Davis,Bountiful 16,U.S. House,2,,Bill Barron,2
-Davis,Bountiful 17,U.S. House,2,,Bill Barron,-
-Davis,Bountiful 18,U.S. House,2,,Bill Barron,-
+Davis,Bountiful 17,U.S. House,2,,Bill Barron,
+Davis,Bountiful 18,U.S. House,2,,Bill Barron,
 Davis,Bountiful 19,U.S. House,2,,Bill Barron,5
 Davis,Bountiful 20,U.S. House,2,,Bill Barron,5
 Davis,Bountiful 21,U.S. House,2,,Bill Barron,3
 Davis,Bountiful 22,U.S. House,2,,Bill Barron,1
 Davis,Bountiful 23,U.S. House,2,,Bill Barron,4
-Davis,Bountiful 24,U.S. House,2,,Bill Barron,-
+Davis,Bountiful 24,U.S. House,2,,Bill Barron,
 Davis,Bountiful 25,U.S. House,2,,Bill Barron,7
 Davis,Bountiful 26,U.S. House,2,,Bill Barron,6
 Davis,Bountiful 27,U.S. House,2,,Bill Barron,4
@@ -1828,7 +1828,7 @@ Davis,Centerville 4,U.S. House,2,,Bill Barron,6
 Davis,Centerville 5,U.S. House,2,,Bill Barron,4
 Davis,Centerville 6,U.S. House,2,,Bill Barron,1
 Davis,Centerville 7,U.S. House,2,,Bill Barron,1
-Davis,Centerville 8,U.S. House,2,,Bill Barron,-
+Davis,Centerville 8,U.S. House,2,,Bill Barron,
 Davis,Centerville 9,U.S. House,2,,Bill Barron,2
 Davis,Centerville 10,U.S. House,2,,Bill Barron,2
 Davis,Centerville 11,U.S. House,2,,Bill Barron,1
@@ -1836,7 +1836,7 @@ Davis,Farmington 1,U.S. House,2,,Bill Barron,1
 Davis,Farmington 2,U.S. House,2,,Bill Barron,1
 Davis,Farmington 3,U.S. House,2,,Bill Barron,2
 Davis,Farmington 4,U.S. House,2,,Bill Barron,3
-Davis,Farmington 5,U.S. House,2,,Bill Barron,-
+Davis,Farmington 5,U.S. House,2,,Bill Barron,
 Davis,Farmington 6,U.S. House,2,,Bill Barron,5
 Davis,Farmington 7,U.S. House,2,,Bill Barron,2
 Davis,Farmington 8,U.S. House,2,,Bill Barron,4
@@ -1849,7 +1849,7 @@ Davis,Kaysville 15,U.S. House,2,,Bill Barron,1
 Davis,North Salt Lake 1,U.S. House,2,,Bill Barron,4
 Davis,North Salt Lake 2,U.S. House,2,,Bill Barron,4
 Davis,North Salt Lake 3,U.S. House,2,,Bill Barron,4
-Davis,North Salt Lake 4,U.S. House,2,,Bill Barron,-
+Davis,North Salt Lake 4,U.S. House,2,,Bill Barron,
 Davis,North Salt Lake 5,U.S. House,2,,Bill Barron,1
 Davis,North Salt Lake 6,U.S. House,2,,Bill Barron,4
 Davis,North Salt Lake 7,U.S. House,2,,Bill Barron,2
@@ -1921,8 +1921,8 @@ Davis,Clearfield 10,Attorney General,,,W. Andrew McCullough,11
 Davis,Clearfield 11,Attorney General,,,W. Andrew McCullough,11
 Davis,Clearfield 12,Attorney General,,,W. Andrew McCullough,13
 Davis,Clearfield 13,Attorney General,,,W. Andrew McCullough,1
-Davis,Clearfield 14,Attorney General,,,W. Andrew McCullough,-
-Davis,Clearfield 15,Attorney General,,,W. Andrew McCullough,-
+Davis,Clearfield 14,Attorney General,,,W. Andrew McCullough,
+Davis,Clearfield 15,Attorney General,,,W. Andrew McCullough,
 Davis,Clinton 1,Attorney General,,,W. Andrew McCullough,14
 Davis,Clinton 2,Attorney General,,,W. Andrew McCullough,12
 Davis,Clinton 3,Attorney General,,,W. Andrew McCullough,5
@@ -1953,7 +1953,7 @@ Davis,Fruit Heights 2,Attorney General,,,W. Andrew McCullough,12
 Davis,Fruit Heights 3,Attorney General,,,W. Andrew McCullough,15
 Davis,Fruit Heights 4,Attorney General,,,W. Andrew McCullough,9
 Davis,Hill AFB 1,Attorney General,,,W. Andrew McCullough,2
-Davis,Hill AFB 2,Attorney General,,,W. Andrew McCullough,-
+Davis,Hill AFB 2,Attorney General,,,W. Andrew McCullough,
 Davis,Kaysville 1,Attorney General,,,W. Andrew McCullough,10
 Davis,Kaysville 2,Attorney General,,,W. Andrew McCullough,12
 Davis,Kaysville 3,Attorney General,,,W. Andrew McCullough,15
@@ -2030,7 +2030,7 @@ Davis,North Salt Lake 10,Attorney General,,,W. Andrew McCullough,7
 Davis,South Weber 1,Attorney General,,,W. Andrew McCullough,15
 Davis,South Weber 2,Attorney General,,,W. Andrew McCullough,14
 Davis,South Weber 3,Attorney General,,,W. Andrew McCullough,17
-Davis,South Weber 4,Attorney General,,,W. Andrew McCullough,-
+Davis,South Weber 4,Attorney General,,,W. Andrew McCullough,
 Davis,Sunset 1,Attorney General,,,W. Andrew McCullough,11
 Davis,Sunset 2,Attorney General,,,W. Andrew McCullough,18
 Davis,Sunset 3,Attorney General,,,W. Andrew McCullough,14
@@ -2058,7 +2058,7 @@ Davis,West Point 3,Attorney General,,,W. Andrew McCullough,7
 Davis,West Point 4,Attorney General,,,W. Andrew McCullough,13
 Davis,West Point 5,Attorney General,,,W. Andrew McCullough,11
 Davis,West Point 6,Attorney General,,,W. Andrew McCullough,6
-Davis,West Point 7,Attorney General,,,W. Andrew McCullough,-
+Davis,West Point 7,Attorney General,,,W. Andrew McCullough,
 Davis,Woods Cross 1,Attorney General,,,W. Andrew McCullough,8
 Davis,Woods Cross 2,Attorney General,,,W. Andrew McCullough,10
 Davis,Woods Cross 3,Attorney General,,,W. Andrew McCullough,10
@@ -2121,7 +2121,7 @@ Davis,Clearfield 11,Attorney General,,,Gregory G. Hansen,20
 Davis,Clearfield 12,Attorney General,,,Gregory G. Hansen,11
 Davis,Clearfield 13,Attorney General,,,Gregory G. Hansen,2
 Davis,Clearfield 14,Attorney General,,,Gregory G. Hansen,2
-Davis,Clearfield 15,Attorney General,,,Gregory G. Hansen,-
+Davis,Clearfield 15,Attorney General,,,Gregory G. Hansen,
 Davis,Clinton 1,Attorney General,,,Gregory G. Hansen,20
 Davis,Clinton 2,Attorney General,,,Gregory G. Hansen,19
 Davis,Clinton 3,Attorney General,,,Gregory G. Hansen,1
@@ -2151,8 +2151,8 @@ Davis,Fruit Heights 1,Attorney General,,,Gregory G. Hansen,19
 Davis,Fruit Heights 2,Attorney General,,,Gregory G. Hansen,18
 Davis,Fruit Heights 3,Attorney General,,,Gregory G. Hansen,14
 Davis,Fruit Heights 4,Attorney General,,,Gregory G. Hansen,7
-Davis,Hill AFB 1,Attorney General,,,Gregory G. Hansen,-
-Davis,Hill AFB 2,Attorney General,,,Gregory G. Hansen,-
+Davis,Hill AFB 1,Attorney General,,,Gregory G. Hansen,
+Davis,Hill AFB 2,Attorney General,,,Gregory G. Hansen,
 Davis,Kaysville 1,Attorney General,,,Gregory G. Hansen,23
 Davis,Kaysville 2,Attorney General,,,Gregory G. Hansen,18
 Davis,Kaysville 3,Attorney General,,,Gregory G. Hansen,14
@@ -2229,7 +2229,7 @@ Davis,North Salt Lake 10,Attorney General,,,Gregory G. Hansen,7
 Davis,South Weber 1,Attorney General,,,Gregory G. Hansen,18
 Davis,South Weber 2,Attorney General,,,Gregory G. Hansen,11
 Davis,South Weber 3,Attorney General,,,Gregory G. Hansen,15
-Davis,South Weber 4,Attorney General,,,Gregory G. Hansen,-
+Davis,South Weber 4,Attorney General,,,Gregory G. Hansen,
 Davis,Sunset 1,Attorney General,,,Gregory G. Hansen,6
 Davis,Sunset 2,Attorney General,,,Gregory G. Hansen,19
 Davis,Sunset 3,Attorney General,,,Gregory G. Hansen,14
@@ -2318,7 +2318,7 @@ Davis,Clearfield 9,Attorney General,,,Charles A. Stormont,57
 Davis,Clearfield 10,Attorney General,,,Charles A. Stormont,50
 Davis,Clearfield 11,Attorney General,,,Charles A. Stormont,104
 Davis,Clearfield 12,Attorney General,,,Charles A. Stormont,78
-Davis,Clearfield 13,Attorney General,,,Charles A. Stormont,-
+Davis,Clearfield 13,Attorney General,,,Charles A. Stormont,
 Davis,Clearfield 14,Attorney General,,,Charles A. Stormont,2
 Davis,Clearfield 15,Attorney General,,,Charles A. Stormont,2
 Davis,Clinton 1,Attorney General,,,Charles A. Stormont,64
@@ -2351,7 +2351,7 @@ Davis,Fruit Heights 2,Attorney General,,,Charles A. Stormont,67
 Davis,Fruit Heights 3,Attorney General,,,Charles A. Stormont,76
 Davis,Fruit Heights 4,Attorney General,,,Charles A. Stormont,61
 Davis,Hill AFB 1,Attorney General,,,Charles A. Stormont,1
-Davis,Hill AFB 2,Attorney General,,,Charles A. Stormont,-
+Davis,Hill AFB 2,Attorney General,,,Charles A. Stormont,
 Davis,Kaysville 1,Attorney General,,,Charles A. Stormont,77
 Davis,Kaysville 2,Attorney General,,,Charles A. Stormont,61
 Davis,Kaysville 3,Attorney General,,,Charles A. Stormont,49
@@ -2550,7 +2550,7 @@ Davis,Fruit Heights 2,Attorney General,,,Sean D. Reye,301
 Davis,Fruit Heights 3,Attorney General,,,Sean D. Reye,371
 Davis,Fruit Heights 4,Attorney General,,,Sean D. Reye,275
 Davis,Hill AFB 1,Attorney General,,,Sean D. Reye,6
-Davis,Hill AFB 2,Attorney General,,,Sean D. Reye,-
+Davis,Hill AFB 2,Attorney General,,,Sean D. Reye,
 Davis,Kaysville 1,Attorney General,,,Sean D. Reye,307
 Davis,Kaysville 2,Attorney General,,,Sean D. Reye,370
 Davis,Kaysville 3,Attorney General,,,Sean D. Reye,310
@@ -2627,7 +2627,7 @@ Davis,North Salt Lake 10,Attorney General,,,Sean D. Reye,121
 Davis,South Weber 1,Attorney General,,,Sean D. Reye,231
 Davis,South Weber 2,Attorney General,,,Sean D. Reye,273
 Davis,South Weber 3,Attorney General,,,Sean D. Reye,353
-Davis,South Weber 4,Attorney General,,,Sean D. Reye,-
+Davis,South Weber 4,Attorney General,,,Sean D. Reye,
 Davis,Sunset 1,Attorney General,,,Sean D. Reye,100
 Davis,Sunset 2,Attorney General,,,Sean D. Reye,121
 Davis,Sunset 3,Attorney General,,,Sean D. Reye,167
@@ -2718,7 +2718,7 @@ Davis,Clearfield 11,Attorney General,,,Leslie D. Curtis,11
 Davis,Clearfield 12,Attorney General,,,Leslie D. Curtis,6
 Davis,Clearfield 13,Attorney General,,,Leslie D. Curtis,2
 Davis,Clearfield 14,Attorney General,,,Leslie D. Curtis,1
-Davis,Clearfield 15,Attorney General,,,Leslie D. Curtis,-
+Davis,Clearfield 15,Attorney General,,,Leslie D. Curtis,
 Davis,Clinton 1,Attorney General,,,Leslie D. Curtis,8
 Davis,Clinton 2,Attorney General,,,Leslie D. Curtis,16
 Davis,Clinton 3,Attorney General,,,Leslie D. Curtis,2
@@ -2749,7 +2749,7 @@ Davis,Fruit Heights 2,Attorney General,,,Leslie D. Curtis,9
 Davis,Fruit Heights 3,Attorney General,,,Leslie D. Curtis,6
 Davis,Fruit Heights 4,Attorney General,,,Leslie D. Curtis,5
 Davis,Hill AFB 1,Attorney General,,,Leslie D. Curtis,1
-Davis,Hill AFB 2,Attorney General,,,Leslie D. Curtis,-
+Davis,Hill AFB 2,Attorney General,,,Leslie D. Curtis,
 Davis,Kaysville 1,Attorney General,,,Leslie D. Curtis,10
 Davis,Kaysville 2,Attorney General,,,Leslie D. Curtis,10
 Davis,Kaysville 3,Attorney General,,,Leslie D. Curtis,8
@@ -2826,7 +2826,7 @@ Davis,North Salt Lake 10,Attorney General,,,Leslie D. Curtis,5
 Davis,South Weber 1,Attorney General,,,Leslie D. Curtis,23
 Davis,South Weber 2,Attorney General,,,Leslie D. Curtis,8
 Davis,South Weber 3,Attorney General,,,Leslie D. Curtis,17
-Davis,South Weber 4,Attorney General,,,Leslie D. Curtis,-
+Davis,South Weber 4,Attorney General,,,Leslie D. Curtis,
 Davis,Sunset 1,Attorney General,,,Leslie D. Curtis,10
 Davis,Sunset 2,Attorney General,,,Leslie D. Curtis,12
 Davis,Sunset 3,Attorney General,,,Leslie D. Curtis,16
@@ -2869,7 +2869,7 @@ Davis,Hill AFB 1,State Senate,18,,Ann Millner,8
 Davis,South Weber 1,State Senate,18,,Ann Millner,267
 Davis,South Weber 2,State Senate,18,,Ann Millner,305
 Davis,South Weber 3,State Senate,18,,Ann Millner,380
-Davis,South Weber 4,State Senate,18,,Ann Millner,-
+Davis,South Weber 4,State Senate,18,,Ann Millner,
 Davis,Sunset 1,State Senate,18,,Ann Millner,115
 Davis,Clearfield 6,State Senate,18,,Mat Wenzel,78
 Davis,Clearfield 13,State Senate,18,,Mat Wenzel,2
@@ -3126,7 +3126,7 @@ Davis,Centerville 7,State Senate,22,,Brent Zimmerman,19
 Davis,Centerville 9,State Senate,22,,Brent Zimmerman,16
 Davis,Centerville 10,State Senate,22,,Brent Zimmerman,16
 Davis,Centerville 11,State Senate,22,,Brent Zimmerman,21
-Davis,Clearfield 15,State Senate,22,,Brent Zimmerman,-
+Davis,Clearfield 15,State Senate,22,,Brent Zimmerman,
 Davis,Farmington 1,State Senate,22,,Brent Zimmerman,21
 Davis,Farmington 2,State Senate,22,,Brent Zimmerman,24
 Davis,Farmington 3,State Senate,22,,Brent Zimmerman,28
@@ -3190,14 +3190,14 @@ Davis,Layton 42,State Senate,22,,Brent Zimmerman,15
 Davis,Layton 43,State Senate,22,,Brent Zimmerman,24
 Davis,Clearfield 13,State House,11,,Amy Steed Morgan,1
 Davis,Hill AFB 1,State House,11,,Amy Steed Morgan,4
-Davis,Hill AFB 2,State House,11,,Amy Steed Morgan,-
+Davis,Hill AFB 2,State House,11,,Amy Steed Morgan,
 Davis,Layton 2,State House,11,,Amy Steed Morgan,133
 Davis,South Weber 1,State House,11,,Amy Steed Morgan,102
 Davis,South Weber 2,State House,11,,Amy Steed Morgan,134
 Davis,South Weber 3,State House,11,,Amy Steed Morgan,127
 Davis,Clearfield 13,State House,11,,Brad Dee,14
 Davis,Hill AFB 1,State House,11,,Brad Dee,6
-Davis,Hill AFB 2,State House,11,,Brad Dee,-
+Davis,Hill AFB 2,State House,11,,Brad Dee,
 Davis,Layton 2,State House,11,,Brad Dee,255
 Davis,South Weber 1,State House,11,,Brad Dee,259
 Davis,South Weber 2,State House,11,,Brad Dee,262
@@ -3357,7 +3357,7 @@ Davis,Layton 22,State House,16,,Steve Handy,255
 Davis,Layton 23,State House,16,,Steve Handy,329
 Davis,Layton 25,State House,16,,Steve Handy,134
 Davis,Layton 26,State House,16,,Steve Handy,319
-Davis,South Weber 4,State House,16,,Steve Handy,-
+Davis,South Weber 4,State House,16,,Steve Handy,
 Davis,Clearfield 12,State House,16,,Douglas M Sill,79
 Davis,Clearfield 14,State House,16,,Douglas M Sill,4
 Davis,Clearfield 15,State House,16,,Douglas M Sill,2
@@ -3385,8 +3385,8 @@ Davis,Layton 25,State House,16,,Douglas M Sill,46
 Davis,Layton 26,State House,16,,Douglas M Sill,83
 Davis,South Weber 4,State House,16,,Douglas M Sill,2
 Davis,Clearfield 12,State House,16,,Jeffrey Ostler,22
-Davis,Clearfield 14,State House,16,,Jeffrey Ostler,-
-Davis,Clearfield 15,State House,16,,Jeffrey Ostler,-
+Davis,Clearfield 14,State House,16,,Jeffrey Ostler,
+Davis,Clearfield 15,State House,16,,Jeffrey Ostler,
 Davis,Layton 1,State House,16,,Jeffrey Ostler,11
 Davis,Layton 3,State House,16,,Jeffrey Ostler,7
 Davis,Layton 4,State House,16,,Jeffrey Ostler,39
@@ -3409,7 +3409,7 @@ Davis,Layton 22,State House,16,,Jeffrey Ostler,33
 Davis,Layton 23,State House,16,,Jeffrey Ostler,28
 Davis,Layton 25,State House,16,,Jeffrey Ostler,10
 Davis,Layton 26,State House,16,,Jeffrey Ostler,27
-Davis,South Weber 4,State House,16,,Jeffrey Ostler,-
+Davis,South Weber 4,State House,16,,Jeffrey Ostler,
 Davis,Fruit Heights 1,State House,17,,Eric Last,89
 Davis,Fruit Heights 2,State House,17,,Eric Last,77
 Davis,Fruit Heights 3,State House,17,,Eric Last,81

--- a/2014/20141104__ut__general__utah__precinct.csv
+++ b/2014/20141104__ut__general__utah__precinct.csv
@@ -3633,15 +3633,15 @@ Utah,SF07,U.S. House,4,IAP,Tim Aalders,0
 Utah,SF07:UN,U.S. House,4,IAP,Tim Aalders,0
 Utah,SF07S,U.S. House,4,IAP,Tim Aalders,0
 Utah,SP17,U.S. House,4,IAP,Tim Aalders,0
-Utah,SP18,U.S. House,4,IAP,Tim Aalders,-
+Utah,SP18,U.S. House,4,IAP,Tim Aalders,
 Utah,SQ01,U.S. House,4,IAP,Tim Aalders,3
 Utah,SQ01:UN,U.S. House,4,IAP,Tim Aalders,0
 Utah,SQ02,U.S. House,4,IAP,Tim Aalders,10
 Utah,SQ02:UN,U.S. House,4,IAP,Tim Aalders,0
-Utah,SQ03,U.S. House,4,IAP,Tim Aalders,-
-Utah,SQ03:UN,U.S. House,4,IAP,Tim Aalders,-
-Utah,SQ04,U.S. House,4,IAP,Tim Aalders,-
-Utah,SQ04:UN,U.S. House,4,IAP,Tim Aalders,-
+Utah,SQ03,U.S. House,4,IAP,Tim Aalders,
+Utah,SQ03:UN,U.S. House,4,IAP,Tim Aalders,
+Utah,SQ04,U.S. House,4,IAP,Tim Aalders,
+Utah,SQ04:UN,U.S. House,4,IAP,Tim Aalders,
 Utah,SR01,U.S. House,4,IAP,Tim Aalders,5
 Utah,SR02,U.S. House,4,IAP,Tim Aalders,9
 Utah,SR02:UN,U.S. House,4,IAP,Tim Aalders,0
@@ -3874,22 +3874,22 @@ Utah,AF13,U.S. House,4,LIB,Jim L Vein,2
 Utah,AF13:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,AF14,U.S. House,4,LIB,Jim L Vein,0
 Utah,AF14:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,AL01,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL01:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL02,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL02:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL03,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL04,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL05,U.S. House,4,LIB,Jim L Vein,-
-Utah,AL06,U.S. House,4,LIB,Jim L Vein,-
+Utah,AL01,U.S. House,4,LIB,Jim L Vein,
+Utah,AL01:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,AL02,U.S. House,4,LIB,Jim L Vein,
+Utah,AL02:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,AL03,U.S. House,4,LIB,Jim L Vein,
+Utah,AL04,U.S. House,4,LIB,Jim L Vein,
+Utah,AL05,U.S. House,4,LIB,Jim L Vein,
+Utah,AL06,U.S. House,4,LIB,Jim L Vein,
 Utah,CF01,U.S. House,4,LIB,Jim L Vein,2
-Utah,CH01,U.S. House,4,LIB,Jim L Vein,-
-Utah,CH02,U.S. House,4,LIB,Jim L Vein,-
-Utah,CH02:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,CH03,U.S. House,4,LIB,Jim L Vein,-
-Utah,CH04,U.S. House,4,LIB,Jim L Vein,-
-Utah,CH05,U.S. House,4,LIB,Jim L Vein,-
-Utah,DR01,U.S. House,4,LIB,Jim L Vein,-
+Utah,CH01,U.S. House,4,LIB,Jim L Vein,
+Utah,CH02,U.S. House,4,LIB,Jim L Vein,
+Utah,CH02:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,CH03,U.S. House,4,LIB,Jim L Vein,
+Utah,CH04,U.S. House,4,LIB,Jim L Vein,
+Utah,CH05,U.S. House,4,LIB,Jim L Vein,
+Utah,DR01,U.S. House,4,LIB,Jim L Vein,
 Utah,EM01,U.S. House,4,LIB,Jim L Vein,5
 Utah,EM02,U.S. House,4,LIB,Jim L Vein,7
 Utah,EM03,U.S. House,4,LIB,Jim L Vein,3
@@ -3899,173 +3899,173 @@ Utah,EM06,U.S. House,4,LIB,Jim L Vein,7
 Utah,EM07,U.S. House,4,LIB,Jim L Vein,5
 Utah,EM08,U.S. House,4,LIB,Jim L Vein,2
 Utah,EM09,U.S. House,4,LIB,Jim L Vein,3
-Utah,ER01,U.S. House,4,LIB,Jim L Vein,-
-Utah,ER02,U.S. House,4,LIB,Jim L Vein,-
-Utah,ER02:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,ER01,U.S. House,4,LIB,Jim L Vein,
+Utah,ER02,U.S. House,4,LIB,Jim L Vein,
+Utah,ER02:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,FF01,U.S. House,4,LIB,Jim L Vein,1
 Utah,GE01,U.S. House,4,LIB,Jim L Vein,3
 Utah,GO01,U.S. House,4,LIB,Jim L Vein,2
 Utah,GO02,U.S. House,4,LIB,Jim L Vein,1
-Utah,HI01,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI02,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI03,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI03:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI04,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI05,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI05:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI06,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI06:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI07,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI08,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI08:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI09,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI09:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,HI10,U.S. House,4,LIB,Jim L Vein,-
+Utah,HI01,U.S. House,4,LIB,Jim L Vein,
+Utah,HI02,U.S. House,4,LIB,Jim L Vein,
+Utah,HI03,U.S. House,4,LIB,Jim L Vein,
+Utah,HI03:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,HI04,U.S. House,4,LIB,Jim L Vein,
+Utah,HI05,U.S. House,4,LIB,Jim L Vein,
+Utah,HI05:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,HI06,U.S. House,4,LIB,Jim L Vein,
+Utah,HI06:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,HI07,U.S. House,4,LIB,Jim L Vein,
+Utah,HI08,U.S. House,4,LIB,Jim L Vein,
+Utah,HI08:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,HI09,U.S. House,4,LIB,Jim L Vein,
+Utah,HI09:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,HI10,U.S. House,4,LIB,Jim L Vein,
 Utah,LE01,U.S. House,4,LIB,Jim L Vein,6
 Utah,LE01:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LE01S,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE01S:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE01S,U.S. House,4,LIB,Jim L Vein,
+Utah,LE01S:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE02,U.S. House,4,LIB,Jim L Vein,6
-Utah,LE03,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE03:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE03,U.S. House,4,LIB,Jim L Vein,
+Utah,LE03:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE04,U.S. House,4,LIB,Jim L Vein,3
 Utah,LE04:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,LE05,U.S. House,4,LIB,Jim L Vein,5
 Utah,LE05:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LE06,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE06:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE06S,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE07,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE07:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE06,U.S. House,4,LIB,Jim L Vein,
+Utah,LE06:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE06S,U.S. House,4,LIB,Jim L Vein,
+Utah,LE07,U.S. House,4,LIB,Jim L Vein,
+Utah,LE07:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE08,U.S. House,4,LIB,Jim L Vein,3
 Utah,LE08:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LE09,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE09:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE10,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE10:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE09,U.S. House,4,LIB,Jim L Vein,
+Utah,LE09:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE10,U.S. House,4,LIB,Jim L Vein,
+Utah,LE10:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE11,U.S. House,4,LIB,Jim L Vein,5
 Utah,LE11:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LE12,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE12:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE12,U.S. House,4,LIB,Jim L Vein,
+Utah,LE12:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE13,U.S. House,4,LIB,Jim L Vein,0
 Utah,LE13:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,LE14,U.S. House,4,LIB,Jim L Vein,4
-Utah,LE15,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE15:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE16,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE16:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE17,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE17:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE18,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE18:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE15,U.S. House,4,LIB,Jim L Vein,
+Utah,LE15:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE16,U.S. House,4,LIB,Jim L Vein,
+Utah,LE16:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE17,U.S. House,4,LIB,Jim L Vein,
+Utah,LE17:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE18,U.S. House,4,LIB,Jim L Vein,
+Utah,LE18:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,LE19,U.S. House,4,LIB,Jim L Vein,7
 Utah,LE19:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LE20,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE20:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,LE21,U.S. House,4,LIB,Jim L Vein,-
+Utah,LE20,U.S. House,4,LIB,Jim L Vein,
+Utah,LE20:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,LE21,U.S. House,4,LIB,Jim L Vein,
 Utah,LE22,U.S. House,4,LIB,Jim L Vein,1
 Utah,LE22:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,LE23,U.S. House,4,LIB,Jim L Vein,3
 Utah,LE23:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,LI01,U.S. House,4,LIB,Jim L Vein,-
-Utah,LI02,U.S. House,4,LIB,Jim L Vein,-
-Utah,LI03,U.S. House,4,LIB,Jim L Vein,-
-Utah,LI04,U.S. House,4,LIB,Jim L Vein,-
-Utah,LI05,U.S. House,4,LIB,Jim L Vein,-
-Utah,LI06,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA01,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA02,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA02:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA03,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA04,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA05,U.S. House,4,LIB,Jim L Vein,-
-Utah,MA05:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR01,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR02,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR03,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR04,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR05,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR06,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR07,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR08,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR09,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR10,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR11,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR12,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR13,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR14,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR15,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR16,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR17,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR18,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR19,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR20,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR21,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR22,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR23,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR24,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR25,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR26,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR27,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR28,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR29,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR30,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR31,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR32,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR33,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR34,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR35,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR36,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR36:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR37,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR38,U.S. House,4,LIB,Jim L Vein,-
-Utah,OR39,U.S. House,4,LIB,Jim L Vein,-
+Utah,LI01,U.S. House,4,LIB,Jim L Vein,
+Utah,LI02,U.S. House,4,LIB,Jim L Vein,
+Utah,LI03,U.S. House,4,LIB,Jim L Vein,
+Utah,LI04,U.S. House,4,LIB,Jim L Vein,
+Utah,LI05,U.S. House,4,LIB,Jim L Vein,
+Utah,LI06,U.S. House,4,LIB,Jim L Vein,
+Utah,MA01,U.S. House,4,LIB,Jim L Vein,
+Utah,MA02,U.S. House,4,LIB,Jim L Vein,
+Utah,MA02:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,MA03,U.S. House,4,LIB,Jim L Vein,
+Utah,MA04,U.S. House,4,LIB,Jim L Vein,
+Utah,MA05,U.S. House,4,LIB,Jim L Vein,
+Utah,MA05:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,OR01,U.S. House,4,LIB,Jim L Vein,
+Utah,OR02,U.S. House,4,LIB,Jim L Vein,
+Utah,OR03,U.S. House,4,LIB,Jim L Vein,
+Utah,OR04,U.S. House,4,LIB,Jim L Vein,
+Utah,OR05,U.S. House,4,LIB,Jim L Vein,
+Utah,OR06,U.S. House,4,LIB,Jim L Vein,
+Utah,OR07,U.S. House,4,LIB,Jim L Vein,
+Utah,OR08,U.S. House,4,LIB,Jim L Vein,
+Utah,OR09,U.S. House,4,LIB,Jim L Vein,
+Utah,OR10,U.S. House,4,LIB,Jim L Vein,
+Utah,OR11,U.S. House,4,LIB,Jim L Vein,
+Utah,OR12,U.S. House,4,LIB,Jim L Vein,
+Utah,OR13,U.S. House,4,LIB,Jim L Vein,
+Utah,OR14,U.S. House,4,LIB,Jim L Vein,
+Utah,OR15,U.S. House,4,LIB,Jim L Vein,
+Utah,OR16,U.S. House,4,LIB,Jim L Vein,
+Utah,OR17,U.S. House,4,LIB,Jim L Vein,
+Utah,OR18,U.S. House,4,LIB,Jim L Vein,
+Utah,OR19,U.S. House,4,LIB,Jim L Vein,
+Utah,OR20,U.S. House,4,LIB,Jim L Vein,
+Utah,OR21,U.S. House,4,LIB,Jim L Vein,
+Utah,OR22,U.S. House,4,LIB,Jim L Vein,
+Utah,OR23,U.S. House,4,LIB,Jim L Vein,
+Utah,OR24,U.S. House,4,LIB,Jim L Vein,
+Utah,OR25,U.S. House,4,LIB,Jim L Vein,
+Utah,OR26,U.S. House,4,LIB,Jim L Vein,
+Utah,OR27,U.S. House,4,LIB,Jim L Vein,
+Utah,OR28,U.S. House,4,LIB,Jim L Vein,
+Utah,OR29,U.S. House,4,LIB,Jim L Vein,
+Utah,OR30,U.S. House,4,LIB,Jim L Vein,
+Utah,OR31,U.S. House,4,LIB,Jim L Vein,
+Utah,OR32,U.S. House,4,LIB,Jim L Vein,
+Utah,OR33,U.S. House,4,LIB,Jim L Vein,
+Utah,OR34,U.S. House,4,LIB,Jim L Vein,
+Utah,OR35,U.S. House,4,LIB,Jim L Vein,
+Utah,OR36,U.S. House,4,LIB,Jim L Vein,
+Utah,OR36:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,OR37,U.S. House,4,LIB,Jim L Vein,
+Utah,OR38,U.S. House,4,LIB,Jim L Vein,
+Utah,OR39,U.S. House,4,LIB,Jim L Vein,
 Utah,PA06,U.S. House,4,LIB,Jim L Vein,0
 Utah,PA06:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,SF07,U.S. House,4,LIB,Jim L Vein,0
 Utah,SF07:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,SF07S,U.S. House,4,LIB,Jim L Vein,0
-Utah,SF12,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF12:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF13,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF13:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF14,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF15,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF16,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF17,U.S. House,4,LIB,Jim L Vein,-
-Utah,SF17:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP01,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP02,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP02:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP03,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP03:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP04,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP04:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP05,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP06,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP07,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP07:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP08,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP09,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP09:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP10,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP11,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP12,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP13,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP14,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP14:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP15,U.S. House,4,LIB,Jim L Vein,-
-Utah,SP16,U.S. House,4,LIB,Jim L Vein,-
+Utah,SF12,U.S. House,4,LIB,Jim L Vein,
+Utah,SF12:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SF13,U.S. House,4,LIB,Jim L Vein,
+Utah,SF13:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SF14,U.S. House,4,LIB,Jim L Vein,
+Utah,SF15,U.S. House,4,LIB,Jim L Vein,
+Utah,SF16,U.S. House,4,LIB,Jim L Vein,
+Utah,SF17,U.S. House,4,LIB,Jim L Vein,
+Utah,SF17:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP01,U.S. House,4,LIB,Jim L Vein,
+Utah,SP02,U.S. House,4,LIB,Jim L Vein,
+Utah,SP02:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP03,U.S. House,4,LIB,Jim L Vein,
+Utah,SP03:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP04,U.S. House,4,LIB,Jim L Vein,
+Utah,SP04:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP05,U.S. House,4,LIB,Jim L Vein,
+Utah,SP06,U.S. House,4,LIB,Jim L Vein,
+Utah,SP07,U.S. House,4,LIB,Jim L Vein,
+Utah,SP07:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP08,U.S. House,4,LIB,Jim L Vein,
+Utah,SP09,U.S. House,4,LIB,Jim L Vein,
+Utah,SP09:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP10,U.S. House,4,LIB,Jim L Vein,
+Utah,SP11,U.S. House,4,LIB,Jim L Vein,
+Utah,SP12,U.S. House,4,LIB,Jim L Vein,
+Utah,SP13,U.S. House,4,LIB,Jim L Vein,
+Utah,SP14,U.S. House,4,LIB,Jim L Vein,
+Utah,SP14:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SP15,U.S. House,4,LIB,Jim L Vein,
+Utah,SP16,U.S. House,4,LIB,Jim L Vein,
 Utah,SP17,U.S. House,4,LIB,Jim L Vein,0
-Utah,SP18,U.S. House,4,LIB,Jim L Vein,-
+Utah,SP18,U.S. House,4,LIB,Jim L Vein,
 Utah,SQ01,U.S. House,4,LIB,Jim L Vein,2
 Utah,SQ01:UN,U.S. House,4,LIB,Jim L Vein,0
 Utah,SQ02,U.S. House,4,LIB,Jim L Vein,5
 Utah,SQ02:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,SQ03,U.S. House,4,LIB,Jim L Vein,-
-Utah,SQ03:UN,U.S. House,4,LIB,Jim L Vein,-
-Utah,SQ04,U.S. House,4,LIB,Jim L Vein,-
-Utah,SQ04:UN,U.S. House,4,LIB,Jim L Vein,-
+Utah,SQ03,U.S. House,4,LIB,Jim L Vein,
+Utah,SQ03:UN,U.S. House,4,LIB,Jim L Vein,
+Utah,SQ04,U.S. House,4,LIB,Jim L Vein,
+Utah,SQ04:UN,U.S. House,4,LIB,Jim L Vein,
 Utah,SR01,U.S. House,4,LIB,Jim L Vein,5
 Utah,SR02,U.S. House,4,LIB,Jim L Vein,2
 Utah,SR02:UN,U.S. House,4,LIB,Jim L Vein,0
@@ -4077,9 +4077,9 @@ Utah,SR06,U.S. House,4,LIB,Jim L Vein,5
 Utah,SR07,U.S. House,4,LIB,Jim L Vein,4
 Utah,SR08,U.S. House,4,LIB,Jim L Vein,3
 Utah,SR08:UN,U.S. House,4,LIB,Jim L Vein,0
-Utah,UCBE1,U.S. House,4,LIB,Jim L Vein,-
-Utah,UCBE2,U.S. House,4,LIB,Jim L Vein,-
-Utah,UCCB1,U.S. House,4,LIB,Jim L Vein,-
+Utah,UCBE1,U.S. House,4,LIB,Jim L Vein,
+Utah,UCBE2,U.S. House,4,LIB,Jim L Vein,
+Utah,UCCB1,U.S. House,4,LIB,Jim L Vein,
 Utah,UCCF1,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCCF2,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCEL1,U.S. House,4,LIB,Jim L Vein,1
@@ -4087,19 +4087,19 @@ Utah,UCEL2,U.S. House,4,LIB,Jim L Vein,1
 Utah,UCFF,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCLS1,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCLS2,U.S. House,4,LIB,Jim L Vein,0
-Utah,UCLV,U.S. House,4,LIB,Jim L Vein,-
-Utah,UCPC1,U.S. House,4,LIB,Jim L Vein,-
-Utah,UCPC2,U.S. House,4,LIB,Jim L Vein,-
-Utah,UCSL,U.S. House,4,LIB,Jim L Vein,-
+Utah,UCLV,U.S. House,4,LIB,Jim L Vein,
+Utah,UCPC1,U.S. House,4,LIB,Jim L Vein,
+Utah,UCPC2,U.S. House,4,LIB,Jim L Vein,
+Utah,UCSL,U.S. House,4,LIB,Jim L Vein,
 Utah,UCUL1,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCUL2,U.S. House,4,LIB,Jim L Vein,0
 Utah,UCWM,U.S. House,4,LIB,Jim L Vein,1
-Utah,VI01,U.S. House,4,LIB,Jim L Vein,-
-Utah,VI01S,U.S. House,4,LIB,Jim L Vein,-
-Utah,VI01S2,U.S. House,4,LIB,Jim L Vein,-
-Utah,VI01UL,U.S. House,4,LIB,Jim L Vein,-
-Utah,VI02,U.S. House,4,LIB,Jim L Vein,-
-Utah,WH01,U.S. House,4,LIB,Jim L Vein,-
+Utah,VI01,U.S. House,4,LIB,Jim L Vein,
+Utah,VI01S,U.S. House,4,LIB,Jim L Vein,
+Utah,VI01S2,U.S. House,4,LIB,Jim L Vein,
+Utah,VI01UL,U.S. House,4,LIB,Jim L Vein,
+Utah,VI02,U.S. House,4,LIB,Jim L Vein,
+Utah,WH01,U.S. House,4,LIB,Jim L Vein,
 Utah,AF01,Attorney General,,LIB,W. Andrew McCullough,
 Utah,AF01:UN,Attorney General,,LIB,W. Andrew McCullough,
 Utah,AF02,Attorney General,,LIB,W. Andrew McCullough,
@@ -5973,30 +5973,30 @@ Utah,OR47,STATE SENATE,15,DEM,Emmanuel Kepas,53
 Utah,OR47:UN,STATE SENATE,15,DEM,Emmanuel Kepas,0
 Utah,PG05,STATE SENATE,15,DEM,Emmanuel Kepas,35
 Utah,PG05S,STATE SENATE,15,DEM,Emmanuel Kepas,12
-Utah,PG06,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PG07,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PG08,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PG08:UN,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PG09,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PG06,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PG07,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PG08,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PG08:UN,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PG09,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PG10,STATE SENATE,15,DEM,Emmanuel Kepas,41
 Utah,PG10:UN,STATE SENATE,15,DEM,Emmanuel Kepas,0
-Utah,PG11,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PG12,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PG11,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PG12,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PG13,STATE SENATE,15,DEM,Emmanuel Kepas,21
-Utah,PG14,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR01,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR01:UN,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR02,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR03,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR04,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR05,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR06,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR07,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR08,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR09,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR10,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR11,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR12,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PG14,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR01,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR01:UN,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR02,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR03,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR04,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR05,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR06,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR07,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR08,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR09,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR10,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR11,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR12,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR13,STATE SENATE,15,DEM,Emmanuel Kepas,54
 Utah,PR14,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR15,STATE SENATE,15,DEM,Emmanuel Kepas,
@@ -6007,15 +6007,15 @@ Utah,PR18,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR19,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR20,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR21,STATE SENATE,15,DEM,Emmanuel Kepas,63
-Utah,PR22,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PR22,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR23,STATE SENATE,15,DEM,Emmanuel Kepas,76
-Utah,PR24,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PR24,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR25,STATE SENATE,15,DEM,Emmanuel Kepas,46
-Utah,PR26,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PR26,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR27,STATE SENATE,15,DEM,Emmanuel Kepas,94
-Utah,PR28,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR29,STATE SENATE,15,DEM,Emmanuel Kepas,-
-Utah,PR30,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,PR28,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR29,STATE SENATE,15,DEM,Emmanuel Kepas,
+Utah,PR30,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR31,STATE SENATE,15,DEM,Emmanuel Kepas,92
 Utah,PR32,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,PR33,STATE SENATE,15,DEM,Emmanuel Kepas,
@@ -6128,7 +6128,7 @@ Utah,UCWM,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,VI01,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,VI01S,STATE SENATE,15,DEM,Emmanuel Kepas,1
 Utah,VI01S2,STATE SENATE,15,DEM,Emmanuel Kepas,2
-Utah,VI01UL,STATE SENATE,15,DEM,Emmanuel Kepas,-
+Utah,VI01UL,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,VI02,STATE SENATE,15,DEM,Emmanuel Kepas,0
 Utah,WH01,STATE SENATE,15,DEM,Emmanuel Kepas,
 Utah,AF01,STATE SENATE,15,REP,Margaret Dayton,
@@ -6246,34 +6246,34 @@ Utah,LE19,STATE SENATE,15,REP,Margaret Dayton,
 Utah,LE19:UN,STATE SENATE,15,REP,Margaret Dayton,
 Utah,LE20,STATE SENATE,15,REP,Margaret Dayton,
 Utah,LE20:UN,STATE SENATE,15,REP,Margaret Dayton,
-Utah,LE21,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,LE22,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,LE22:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,LE23,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,LE23:UN,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,LE21,STATE SENATE,15,REP,Margaret Dayton,
+Utah,LE22,STATE SENATE,15,REP,Margaret Dayton,
+Utah,LE22:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,LE23,STATE SENATE,15,REP,Margaret Dayton,
+Utah,LE23:UN,STATE SENATE,15,REP,Margaret Dayton,
 Utah,LI01,STATE SENATE,15,REP,Margaret Dayton,438
 Utah,LI02,STATE SENATE,15,REP,Margaret Dayton,207
-Utah,LI03,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,LI04,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,LI03,STATE SENATE,15,REP,Margaret Dayton,
+Utah,LI04,STATE SENATE,15,REP,Margaret Dayton,
 Utah,LI05,STATE SENATE,15,REP,Margaret Dayton,345
-Utah,LI06,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA01,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA02,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA02:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA03,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA04,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA05,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,MA05:UN,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,LI06,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA01,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA02,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA02:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA03,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA04,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA05,STATE SENATE,15,REP,Margaret Dayton,
+Utah,MA05:UN,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR01,STATE SENATE,15,REP,Margaret Dayton,254
 Utah,OR02,STATE SENATE,15,REP,Margaret Dayton,157
-Utah,OR03,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR03,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR04,STATE SENATE,15,REP,Margaret Dayton,222
-Utah,OR05,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR05,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR06,STATE SENATE,15,REP,Margaret Dayton,260
-Utah,OR07,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR07,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR08,STATE SENATE,15,REP,Margaret Dayton,162
-Utah,OR09,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR10,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR09,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR10,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR11,STATE SENATE,15,REP,Margaret Dayton,364
 Utah,OR12,STATE SENATE,15,REP,Margaret Dayton,78
 Utah,OR13,STATE SENATE,15,REP,Margaret Dayton,167
@@ -6282,25 +6282,25 @@ Utah,OR15,STATE SENATE,15,REP,Margaret Dayton,270
 Utah,OR16,STATE SENATE,15,REP,Margaret Dayton,241
 Utah,OR17,STATE SENATE,15,REP,Margaret Dayton,277
 Utah,OR18,STATE SENATE,15,REP,Margaret Dayton,155
-Utah,OR19,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR19,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR20,STATE SENATE,15,REP,Margaret Dayton,270
 Utah,OR21,STATE SENATE,15,REP,Margaret Dayton,280
 Utah,OR22,STATE SENATE,15,REP,Margaret Dayton,354
 Utah,OR23,STATE SENATE,15,REP,Margaret Dayton,361
-Utah,OR24,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR24,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR25,STATE SENATE,15,REP,Margaret Dayton,212
 Utah,OR26,STATE SENATE,15,REP,Margaret Dayton,275
 Utah,OR27,STATE SENATE,15,REP,Margaret Dayton,283
 Utah,OR28,STATE SENATE,15,REP,Margaret Dayton,367
 Utah,OR29,STATE SENATE,15,REP,Margaret Dayton,340
-Utah,OR30,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR31,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR32,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR33,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR30,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR31,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR32,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR33,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR34,STATE SENATE,15,REP,Margaret Dayton,152
 Utah,OR35,STATE SENATE,15,REP,Margaret Dayton,268
-Utah,OR36,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR36:UN,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR36,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR36:UN,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR37,STATE SENATE,15,REP,Margaret Dayton,211
 Utah,OR38,STATE SENATE,15,REP,Margaret Dayton,204
 Utah,OR39,STATE SENATE,15,REP,Margaret Dayton,99
@@ -6310,57 +6310,57 @@ Utah,OR42,STATE SENATE,15,REP,Margaret Dayton,124
 Utah,OR42S,STATE SENATE,15,REP,Margaret Dayton,29
 Utah,OR43,STATE SENATE,15,REP,Margaret Dayton,318
 Utah,OR44,STATE SENATE,15,REP,Margaret Dayton,186
-Utah,OR45,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR45,STATE SENATE,15,REP,Margaret Dayton,
 Utah,OR46,STATE SENATE,15,REP,Margaret Dayton,280
 Utah,OR47,STATE SENATE,15,REP,Margaret Dayton,340
 Utah,OR47:UN,STATE SENATE,15,REP,Margaret Dayton,12
-Utah,OR48,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR49,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,OR50,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA01,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA01:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA02,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA03,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA03:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA04,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA04:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA05,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA06,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA06:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA07,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PA08,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG01,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG01:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG01S,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG02,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG03,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG04,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,OR48,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR49,STATE SENATE,15,REP,Margaret Dayton,
+Utah,OR50,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA01,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA01:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA02,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA03,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA03:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA04,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA04:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA05,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA06,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA06:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA07,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PA08,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG01,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG01:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG01S,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG02,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG03,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG04,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PG05,STATE SENATE,15,REP,Margaret Dayton,111
 Utah,PG05S,STATE SENATE,15,REP,Margaret Dayton,27
-Utah,PG06,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG07,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG08,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG08:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG09,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PG06,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG07,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG08,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG08:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG09,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PG10,STATE SENATE,15,REP,Margaret Dayton,214
 Utah,PG10:UN,STATE SENATE,15,REP,Margaret Dayton,1
-Utah,PG11,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PG12,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PG11,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PG12,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PG13,STATE SENATE,15,REP,Margaret Dayton,104
-Utah,PG14,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR01,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR01:UN,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR02,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR03,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR04,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR05,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR06,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR07,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR08,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR09,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR10,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR11,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR12,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PG14,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR01,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR01:UN,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR02,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR03,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR04,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR05,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR06,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR07,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR08,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR09,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR10,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR11,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR12,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR13,STATE SENATE,15,REP,Margaret Dayton,330
 Utah,PR14,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR15,STATE SENATE,15,REP,Margaret Dayton,
@@ -6371,15 +6371,15 @@ Utah,PR18,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR19,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR20,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR21,STATE SENATE,15,REP,Margaret Dayton,152
-Utah,PR22,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PR22,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR23,STATE SENATE,15,REP,Margaret Dayton,213
-Utah,PR24,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PR24,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR25,STATE SENATE,15,REP,Margaret Dayton,335
-Utah,PR26,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PR26,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR27,STATE SENATE,15,REP,Margaret Dayton,375
-Utah,PR28,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR29,STATE SENATE,15,REP,Margaret Dayton,-
-Utah,PR30,STATE SENATE,15,REP,Margaret Dayton,-
+Utah,PR28,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR29,STATE SENATE,15,REP,Margaret Dayton,
+Utah,PR30,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR31,STATE SENATE,15,REP,Margaret Dayton,379
 Utah,PR32,STATE SENATE,15,REP,Margaret Dayton,
 Utah,PR33,STATE SENATE,15,REP,Margaret Dayton,

--- a/2018/counties/20180626__ut__primary__washington__precinct.csv
+++ b/2018/counties/20180626__ut__primary__washington__precinct.csv
@@ -448,25 +448,25 @@ Washington,WA72,U.S. Senate,,Mike Kennedy,,57,0,0,4,6,1,0,68
 Washington,WA73,U.S. Senate,,Mike Kennedy,,37,6,0,3,19,0,0,65
 Washington,Total,U.S. Senate,,Mike Kennedy,,2349,2204,0,545,3531,179,0,8808
 Washington,AV51,State House,71,Mark S Borowiak,,0,0,0,0,29,0,0,29
-Washington,COAND,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,COAND,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,COCDSR,State House,71,Mark S Borowiak,,1,0,0,0,12,0,0,13
-Washington,COCNBR,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,CODAV,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,CODIV,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,CODXDR,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,COGL,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,COGUBL,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,COHS74,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,COCNBR,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,CODAV,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,CODIV,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,CODXDR,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,COGL,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,COGUBL,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,COHS74,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,COHV28,State House,71,Mark S Borowiak,,0,0,0,0,0,0,0,0
 Washington,COHV29,State House,71,Mark S Borowiak,,0,0,0,0,2,0,0,2
 Washington,COLEED,State House,71,Mark S Borowiak,,0,0,0,0,29,0,0,29
-Washington,CONCF,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,CONCF,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,CONH,State House,71,Mark S Borowiak,,1,0,0,1,75,0,0,77
-Washington,COPINE,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,COPINE,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,COSN28,State House,71,Mark S Borowiak,,0,0,0,0,2,0,0,2
-Washington,COVE,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,COWH,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,EN82,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,COVE,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,COWH,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,EN82,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,HIL97,State House,71,Mark S Borowiak,,0,0,0,0,12,0,0,12
 Washington,HU52,State House,71,Mark S Borowiak,,40,0,0,3,17,0,0,60
 Washington,HU53,State House,71,Mark S Borowiak,,44,0,0,3,12,0,0,59
@@ -477,108 +477,108 @@ Washington,HU57,State House,71,Mark S Borowiak,,28,0,0,1,11,5,0,45
 Washington,HU58,State House,71,Mark S Borowiak,,48,1,0,6,22,0,0,77
 Washington,HU59,State House,71,Mark S Borowiak,,20,0,0,7,20,0,0,47
 Washington,HU60,State House,71,Mark S Borowiak,,66,2,0,9,45,3,0,125
-Washington,IV76,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,IV77,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,IV78,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,IV79,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,IV80,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,IV76,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,IV77,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,IV78,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,IV79,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,IV80,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,LA85,State House,71,Mark S Borowiak,,4,0,0,0,49,0,0,53
 Washington,LA86,State House,71,Mark S Borowiak,,3,1,0,0,53,0,0,58
 Washington,LA87,State House,71,Mark S Borowiak,,2,0,0,0,47,0,0,49
 Washington,LE90,State House,71,Mark S Borowiak,,0,0,0,0,59,0,0,59
 Washington,NH93,State House,71,Mark S Borowiak,,0,0,0,0,15,0,0,15
 Washington,RC94,State House,71,Mark S Borowiak,,0,0,0,0,6,0,0,6
-Washington,SC71,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SC72,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SC73,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SC74,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG01,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG02,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG03,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG04,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG05,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG06,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG07,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG08,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG09,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG10,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG11,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG12,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG13,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG14,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG15,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG16,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG17,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG18,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG19,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG20,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG21,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG22,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG23,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG24,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG25,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG26,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG27,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG28,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG29,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG30,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG31,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG32,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG33,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG34,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG35,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG36,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG37,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG38,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG39,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG40,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG41,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG42,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG43,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,SC71,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SC72,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SC73,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SC74,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG01,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG02,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG03,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG04,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG05,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG06,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG07,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG08,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG09,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG10,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG11,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG12,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG13,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG14,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG15,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG16,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG17,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG18,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG19,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG20,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG21,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG22,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG23,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG24,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG25,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG26,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG27,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG28,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG29,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG30,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG31,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG32,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG33,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG34,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG35,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG36,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG37,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG38,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG39,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG40,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG41,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG42,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG43,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,SG44,State House,71,Mark S Borowiak,,22,9,0,6,10,2,0,49
-Washington,SG45,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG46,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG47,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG48,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,SG49,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,SG45,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG46,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG47,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG48,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,SG49,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,SP95,State House,71,Mark S Borowiak,,0,0,0,0,13,0,0,15
 Washington,TQ96,State House,71,Mark S Borowiak,,2,0,0,0,79,0,0,81
 Washington,VI89,State House,71,Mark S Borowiak,,1,0,0,0,30,0,0,31
-Washington,WA60,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA61,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA62,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA63,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA64,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA65,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA66,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA67,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA68,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,WA60,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA61,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA62,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA63,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA64,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA65,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA66,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA67,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA68,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,WA69,State House,71,Mark S Borowiak,,9,5,0,9,24,1,0,48
-Washington,WA70,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA71,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA72,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
-Washington,WA73,State House,71,Mark S Borowiak,,-,-,-,-,-,-,-,-
+Washington,WA70,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA71,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA72,State House,71,Mark S Borowiak,,,,,,,,,
+Washington,WA73,State House,71,Mark S Borowiak,,,,,,,,,
 Washington,Total,State House,71,Mark S Borowiak,,378,19,0,52,743,12,0,1204
 Washington,AV51,State House,71,Brad Last,,0,0,0,0,74,0,0,74
-Washington,COAND,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,COAND,State House,71,Brad Last,,,,,,,,,
 Washington,COCDSR,State House,71,Brad Last,,2,0,0,0,30,0,0,32
-Washington,COCNBR,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,CODAV,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,CODIV,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,CODXDR,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,COGL,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,COGUBL,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,COHS74,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,COCNBR,State House,71,Brad Last,,,,,,,,,
+Washington,CODAV,State House,71,Brad Last,,,,,,,,,
+Washington,CODIV,State House,71,Brad Last,,,,,,,,,
+Washington,CODXDR,State House,71,Brad Last,,,,,,,,,
+Washington,COGL,State House,71,Brad Last,,,,,,,,,
+Washington,COGUBL,State House,71,Brad Last,,,,,,,,,
+Washington,COHS74,State House,71,Brad Last,,,,,,,,,
 Washington,COHV28,State House,71,Brad Last,,0,0,0,0,9,0,0,9
 Washington,COHV29,State House,71,Brad Last,,0,0,0,0,1,0,0,1
 Washington,COLEED,State House,71,Brad Last,,0,0,0,0,39,0,0,39
-Washington,CONCF,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,CONCF,State House,71,Brad Last,,,,,,,,,
 Washington,CONH,State House,71,Brad Last,,0,0,0,1,137,0,0,138
-Washington,COPINE,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,COPINE,State House,71,Brad Last,,,,,,,,,
 Washington,COSN28,State House,71,Brad Last,,0,0,0,0,3,0,0,3
-Washington,COVE,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,COWH,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,EN82,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,COVE,State House,71,Brad Last,,,,,,,,,
+Washington,COWH,State House,71,Brad Last,,,,,,,,,
+Washington,EN82,State House,71,Brad Last,,,,,,,,,
 Washington,HIL97,State House,71,Brad Last,,0,0,0,0,36,0,0,36
 Washington,HU52,State House,71,Brad Last,,104,0,0,14,33,3,0,154
 Washington,HU53,State House,71,Brad Last,,96,0,0,10,36,0,0,142
@@ -589,85 +589,85 @@ Washington,HU57,State House,71,Brad Last,,51,0,0,7,37,6,0,101
 Washington,HU58,State House,71,Brad Last,,104,3,0,13,45,0,0,165
 Washington,HU59,State House,71,Brad Last,,44,0,0,2,35,2,0,83
 Washington,HU60,State House,71,Brad Last,,46,0,0,5,56,3,0,110
-Washington,IV76,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,IV77,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,IV78,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,IV79,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,IV80,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,IV76,State House,71,Brad Last,,,,,,,,,
+Washington,IV77,State House,71,Brad Last,,,,,,,,,
+Washington,IV78,State House,71,Brad Last,,,,,,,,,
+Washington,IV79,State House,71,Brad Last,,,,,,,,,
+Washington,IV80,State House,71,Brad Last,,,,,,,,,
 Washington,LA85,State House,71,Brad Last,,4,0,0,1,131,0,0,136
-Washington,LA86,State House,71,Brad Last,,3,1,0,-,106,0,0,110
+Washington,LA86,State House,71,Brad Last,,3,1,0,,106,0,0,110
 Washington,LA87,State House,71,Brad Last,,6,0,0,0,108,0,0,114
 Washington,LE90,State House,71,Brad Last,,0,1,0,0,165,1,0,167
 Washington,NH93,State House,71,Brad Last,,0,0,0,0,41,0,0,41
 Washington,RC94,State House,71,Brad Last,,0,0,0,0,28,0,0,28
-Washington,SC71,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SC72,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SC73,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SC74,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG01,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG02,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG03,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG04,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG05,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG06,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG07,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG08,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG09,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG10,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG11,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG12,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG13,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG14,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG15,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG16,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG17,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG18,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG19,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG20,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG21,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG22,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG23,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG24,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG25,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG26,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG27,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG28,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG29,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG30,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG31,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG32,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG33,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG34,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG35,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG36,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG37,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG38,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG39,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG40,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG41,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG42,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG43,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,SC71,State House,71,Brad Last,,,,,,,,,
+Washington,SC72,State House,71,Brad Last,,,,,,,,,
+Washington,SC73,State House,71,Brad Last,,,,,,,,,
+Washington,SC74,State House,71,Brad Last,,,,,,,,,
+Washington,SG01,State House,71,Brad Last,,,,,,,,,
+Washington,SG02,State House,71,Brad Last,,,,,,,,,
+Washington,SG03,State House,71,Brad Last,,,,,,,,,
+Washington,SG04,State House,71,Brad Last,,,,,,,,,
+Washington,SG05,State House,71,Brad Last,,,,,,,,,
+Washington,SG06,State House,71,Brad Last,,,,,,,,,
+Washington,SG07,State House,71,Brad Last,,,,,,,,,
+Washington,SG08,State House,71,Brad Last,,,,,,,,,
+Washington,SG09,State House,71,Brad Last,,,,,,,,,
+Washington,SG10,State House,71,Brad Last,,,,,,,,,
+Washington,SG11,State House,71,Brad Last,,,,,,,,,
+Washington,SG12,State House,71,Brad Last,,,,,,,,,
+Washington,SG13,State House,71,Brad Last,,,,,,,,,
+Washington,SG14,State House,71,Brad Last,,,,,,,,,
+Washington,SG15,State House,71,Brad Last,,,,,,,,,
+Washington,SG16,State House,71,Brad Last,,,,,,,,,
+Washington,SG17,State House,71,Brad Last,,,,,,,,,
+Washington,SG18,State House,71,Brad Last,,,,,,,,,
+Washington,SG19,State House,71,Brad Last,,,,,,,,,
+Washington,SG20,State House,71,Brad Last,,,,,,,,,
+Washington,SG21,State House,71,Brad Last,,,,,,,,,
+Washington,SG22,State House,71,Brad Last,,,,,,,,,
+Washington,SG23,State House,71,Brad Last,,,,,,,,,
+Washington,SG24,State House,71,Brad Last,,,,,,,,,
+Washington,SG25,State House,71,Brad Last,,,,,,,,,
+Washington,SG26,State House,71,Brad Last,,,,,,,,,
+Washington,SG27,State House,71,Brad Last,,,,,,,,,
+Washington,SG28,State House,71,Brad Last,,,,,,,,,
+Washington,SG29,State House,71,Brad Last,,,,,,,,,
+Washington,SG30,State House,71,Brad Last,,,,,,,,,
+Washington,SG31,State House,71,Brad Last,,,,,,,,,
+Washington,SG32,State House,71,Brad Last,,,,,,,,,
+Washington,SG33,State House,71,Brad Last,,,,,,,,,
+Washington,SG34,State House,71,Brad Last,,,,,,,,,
+Washington,SG35,State House,71,Brad Last,,,,,,,,,
+Washington,SG36,State House,71,Brad Last,,,,,,,,,
+Washington,SG37,State House,71,Brad Last,,,,,,,,,
+Washington,SG38,State House,71,Brad Last,,,,,,,,,
+Washington,SG39,State House,71,Brad Last,,,,,,,,,
+Washington,SG40,State House,71,Brad Last,,,,,,,,,
+Washington,SG41,State House,71,Brad Last,,,,,,,,,
+Washington,SG42,State House,71,Brad Last,,,,,,,,,
+Washington,SG43,State House,71,Brad Last,,,,,,,,,
 Washington,SG44,State House,71,Brad Last,,75,30,0,6,49,10,0,170
-Washington,SG45,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG46,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG47,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG48,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,SG49,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,SG45,State House,71,Brad Last,,,,,,,,,
+Washington,SG46,State House,71,Brad Last,,,,,,,,,
+Washington,SG47,State House,71,Brad Last,,,,,,,,,
+Washington,SG48,State House,71,Brad Last,,,,,,,,,
+Washington,SG49,State House,71,Brad Last,,,,,,,,,
 Washington,SP95,State House,71,Brad Last,,1,0,0,0,62,0,0,63
 Washington,TQ96,State House,71,Brad Last,,1,3,0,1,247,0,0,252
 Washington,VI89,State House,71,Brad Last,,0,0,0,0,84,0,0,84
-Washington,WA60,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA61,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA62,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA63,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA64,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA65,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA66,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA67,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA68,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,WA60,State House,71,Brad Last,,,,,,,,,
+Washington,WA61,State House,71,Brad Last,,,,,,,,,
+Washington,WA62,State House,71,Brad Last,,,,,,,,,
+Washington,WA63,State House,71,Brad Last,,,,,,,,,
+Washington,WA64,State House,71,Brad Last,,,,,,,,,
+Washington,WA65,State House,71,Brad Last,,,,,,,,,
+Washington,WA66,State House,71,Brad Last,,,,,,,,,
+Washington,WA67,State House,71,Brad Last,,,,,,,,,
+Washington,WA68,State House,71,Brad Last,,,,,,,,,
 Washington,WA69,State House,71,Brad Last,,52,17,0,13,57,7,0,146
-Washington,WA70,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA71,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA72,State House,71,Brad Last,,-,-,-,-,-,-,-,-
-Washington,WA73,State House,71,Brad Last,,-,-,-,-,-,-,-,-
+Washington,WA70,State House,71,Brad Last,,,,,,,,,
+Washington,WA71,State House,71,Brad Last,,,,,,,,,
+Washington,WA72,State House,71,Brad Last,,,,,,,,,
+Washington,WA73,State House,71,Brad Last,,,,,,,,,
 Washington,Total,State House,71,Brad Last,,815,55,0,101,1822,37,0,2830


### PR DESCRIPTION
This removes entries that consisted of only non-alphanumeric characters.  These do not appear to be redactions for privacy reasons.