### PR TITLE
clarity_parser: narrow bare except to Exception

### DIFF
--- a/parsers/clarity_parser.py
+++ b/parsers/clarity_parser.py
@@ -60,7 +60,7 @@ def download_county_files(url, filename):
             z = zipfile.ZipFile(BytesIO(r.content))
             z.extractall()
             precinct_results(sub.name.replace(' ','_').lower(),filename)
-        except:
+        except Exception:
             no_xml.append(sub.name)
 
     print(no_xml)


### PR DESCRIPTION
flake8 E722. Same pattern as the other openelections-data clarity_parsers - widen `except:` to `Exception` so KeyboardInterrupt isn't swallowed mid-scrape.